### PR TITLE
CI: Enable cached builds

### DIFF
--- a/.github/workflows/knut-tests.yml
+++ b/.github/workflows/knut-tests.yml
@@ -22,6 +22,11 @@ jobs:
           - ubuntu-latest
           - windows-latest
           - macos-latest
+    env:
+      SCCACHE_CACHE_SIZE: "2G"
+      SCCACHE_GHA_ENABLED: "true"
+      SCCACHE_GHA_CACHE_TO: "sccache-${{ matrix.os }}"
+      SCCACHE_GHA_CACHE_FROM: "sccache-${{ matrix.os }}"
 
     steps:
       - name: Checkout sources
@@ -59,8 +64,11 @@ jobs:
       - name: Make sure MSVC is found when Ninja generator is in use
         uses: ilammy/msvc-dev-cmd@v1
 
+      - name: Run sccache-cache
+        uses: mozilla-actions/sccache-action@v0.0.3
+
       - name: Configure project
-        run: cmake --preset=ci
+        run: cmake -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache --preset=ci
 
       - name: Build Project
         run: cmake --build --preset=ci

--- a/.github/workflows/knut-tests.yml
+++ b/.github/workflows/knut-tests.yml
@@ -65,5 +65,12 @@ jobs:
       - name: Build Project
         run: cmake --build --preset=ci
 
+      - name: Output the build results as an artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: knut-binaries-${{ matrix.os }}-${{ github.head_ref || github.ref_name }}
+          path: build-ci/bin/
+          overwrite: true
+
       - name: Run tests
         run: ctest --preset=ci

--- a/.github/workflows/knut-tests.yml
+++ b/.github/workflows/knut-tests.yml
@@ -76,12 +76,16 @@ jobs:
       - name: Build Project
         run: cmake --build --preset=ci
 
+      - name: Run tests
+        run: ctest --preset=ci
+
+      # We only upload artifacts if building or testing has failed
+      # That way we can debug if necessary, but don't pay the 30s-60s
+      # of upload time if everything is going well.
       - name: Output the build results as an artifact
         uses: actions/upload-artifact@v4
+        if: failure()
         with:
           name: knut-binaries-${{ matrix.os }}-${{ github.head_ref || github.ref_name }}
           path: build-ci/bin/
           overwrite: true
-
-      - name: Run tests
-        run: ctest --preset=ci

--- a/.github/workflows/knut-tests.yml
+++ b/.github/workflows/knut-tests.yml
@@ -18,15 +18,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os:
-          - ubuntu-latest
-          - windows-latest
-          - macos-latest
+        include:
+          - name: Ubuntu
+            os: ubuntu-latest
+            compiler_cache_path: /home/runner/.cache/sccache
+          - name: Windows
+            os: windows-latest
+            compiler_cache_path: C:\Users\runneradmin\AppData\Local\Mozilla\sccache\cache
+          - name: MacOS
+            os: macos-latest
+            compiler_cache_path: /Users/runner/Library/Caches/Mozilla.sccache
+
     env:
       SCCACHE_CACHE_SIZE: "2G"
-      SCCACHE_GHA_ENABLED: "true"
-      SCCACHE_GHA_CACHE_TO: "sccache-${{ matrix.os }}"
-      SCCACHE_GHA_CACHE_FROM: "sccache-${{ matrix.os }}"
 
     steps:
       - name: Inspect Environment Variables
@@ -67,6 +71,30 @@ jobs:
       - name: Make sure MSVC is found when Ninja generator is in use
         uses: ilammy/msvc-dev-cmd@v1
 
+      # Note: The Compiler cache steps were adapted from the CXX-Qt repository (https://github.com/kdab/cxx-qt)
+      #
+      # We want our compiler cache to always update to the newest state.
+      # The best way for us to achieve this is to **always** update the cache after every landed commit.
+      # That way it will closely follow our development.
+      # And if a PR diverges a lot with its cache that's not a big deal, as it will be merged eventually.
+      #
+      # This is a workaround for the fact that GH doesn't support updating existing caches.
+      # See: https://github.com/azu/github-actions-overwrite-cache-example
+      #
+      # Ideally we'd like to use this:
+      # - name: "Compiler cache"
+      #   uses: actions/cache@v4
+      #   with:
+      #     update: true <------- THIS DOESN'T EXIST YET
+      #     path: ${{ matrix.compiler_cache_path }}
+      #     key: ${{ matrix.name }}_compiler_cache
+      - name: "Restore Compiler Cache"
+        id: compiler-cache-restore
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ matrix.compiler_cache_path }}
+          key: ${{ matrix.os }}_compiler_cache
+
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.3
 
@@ -89,3 +117,21 @@ jobs:
           name: knut-binaries-${{ matrix.os }}-${{ github.head_ref || github.ref_name }}
           path: build-ci/bin/
           overwrite: true
+
+      # This is a workaround for the fact that GH doesn't support updating existing caches.
+      # See: https://github.com/azu/github-actions-overwrite-cache-example
+      - name: "Delete previous compiler cache"
+        # Updating th cache doesn't work from forks
+        # So update it once it's merged into the repo
+        if: ${{ steps.compiler-cache-restore.outputs.cache-hit }}
+        continue-on-error: true
+        run: |
+          gh extension install actions/gh-actions-cache
+          gh actions-cache delete "${{ matrix.os }}_compiler_cache" --confirm
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: "Save Compiler Cache"
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ matrix.compiler_cache_path }}
+          key: ${{ matrix.os }}_compiler_cache

--- a/.github/workflows/knut-tests.yml
+++ b/.github/workflows/knut-tests.yml
@@ -29,6 +29,9 @@ jobs:
       SCCACHE_GHA_CACHE_FROM: "sccache-${{ matrix.os }}"
 
     steps:
+      - name: Inspect Environment Variables
+        run: env
+
       - name: Checkout sources
         uses: actions/checkout@v4
 

--- a/.github/workflows/knut-tests.yml
+++ b/.github/workflows/knut-tests.yml
@@ -123,7 +123,7 @@ jobs:
       - name: "Delete previous compiler cache"
         # Updating th cache doesn't work from forks
         # So update it once it's merged into the repo
-        if: ${{ steps.compiler-cache-restore.outputs.cache-hit }}
+        if: ${{ steps.compiler-cache-restore.outputs.cache-hit &&  github.event_name == 'push' }}
         continue-on-error: true
         run: |
           gh extension install actions/gh-actions-cache
@@ -132,6 +132,9 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: "Save Compiler Cache"
         uses: actions/cache/save@v4
+        # Updating th cache doesn't work from forks
+        # So update it once it's merged into the repo
+        if: ${{ github.event_name == 'push' }}
         with:
           path: ${{ matrix.compiler_cache_path }}
           key: ${{ matrix.os }}_compiler_cache

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,7 @@
 cmake_minimum_required(VERSION 3.15)
+# This enables the use of CMAKE_MSVC_DEBUG_INFORMATION_FORMAT as required by the CI preset
+cmake_policy(SET CMP0141 NEW)
+
 # This file is part of Knut.
 #
 # SPDX-FileCopyrightText: 2024 Klarälvdalens Datakonsult AB, a KDAB Group

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,13 +67,11 @@ if(EXISTS "${CMAKE_SOURCE_DIR}/.git")
     message(STATUS "GIT not found!?")
   endif()
 endif()
-add_definitions(-DKNUT_VERSION_STRING="${KNUT_VERSION_STRING}")
 
 # Generate build date for the about dialog Note: This is the simplest way to get
 # a build date out of CMake Drawbacks: The timestamp is only updated when CMake
 # is rerun. But this should sufficient for our use-case.
 string(TIMESTAMP KNUT_BUILDDATE "%Y-%m-%d")
-add_definitions(-DKNUT_BUILDDATE="${KNUT_BUILDDATE}")
 
 # Qt
 # ##############################################################################

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -45,6 +45,7 @@
             "generator": "Ninja",
             "cacheVariables": {
                 "CMAKE_BUILD_TYPE": "RelWithDebInfo",
+                "CMAKE_MSVC_DEBUG_INFORMATION_FORMAT": "Embedded",
                 "KNUT_ERROR_ON_WARN": "ON"
             }
         },

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -10,6 +10,8 @@
 
 project(knut-core LANGUAGES CXX)
 
+configure_file(version.cpp.in ${CMAKE_CURRENT_BINARY_DIR}/version.cpp)
+
 set(PROJECT_SOURCES
     astnode.h
     astnode.cpp
@@ -104,6 +106,8 @@ set(PROJECT_SOURCES
     userdialog.cpp
     utils.h
     utils.cpp
+    version.h
+    ${CMAKE_CURRENT_BINARY_DIR}/version.cpp
     core.qrc)
 
 add_library(${PROJECT_NAME} STATIC ${PROJECT_SOURCES})

--- a/src/core/version.cpp.in
+++ b/src/core/version.cpp.in
@@ -1,0 +1,12 @@
+#include "core/version.h"
+
+namespace core {
+    QString knut_version()
+    {
+        return "${KNUT_VERSION_STRING}";
+    }
+
+    QString knut_build_date() {
+        return "${KNUT_BUILDDATE}";
+    }
+}

--- a/src/core/version.h
+++ b/src/core/version.h
@@ -1,0 +1,8 @@
+#pragma once
+
+#include <QString>
+
+namespace core {
+QString knut_version();
+QString knut_build_date();
+}

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -20,6 +20,7 @@
 #include "core/slintdocument.h"
 #include "core/textdocument.h"
 #include "core/uidocument.h"
+#include "core/version.h"
 #include "documentpalette.h"
 #include "guisettings.h"
 #include "historypanel.h"
@@ -572,7 +573,7 @@ Build date: %2<br/><br/>
 Knut name has nothing to do with Knut Irvin, nor with Knut the polar bear.<br/>
 The name Knut is coming from St Knut, which marks the end of the Christmas and holiday season in Sweden.<br/>
 See Wikipedia article: <a href="https://en.wikipedia.org/wiki/Saint_Knut%27s_Day">Saint Knut's Day</a>.)")
-                    .arg(KNUT_VERSION_STRING, KNUT_BUILDDATE);
+                    .arg(core::knut_version(), core::knut_build_date());
     QMessageBox dialog(QMessageBox::Information, tr("About Knut"), text, QMessageBox::Ok, this);
     dialog.setIconPixmap(QPixmap(":/gui/icons/knut-64.png"));
     dialog.exec();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,6 +8,7 @@
   Contact KDAB at <info@kdab.com> for commercial licensing options.
 */
 
+#include "core/version.h"
 #include "gui/knutmain.h"
 
 #include <QApplication>
@@ -19,7 +20,7 @@ int main(int argc, char *argv[])
 
     QApplication::setOrganizationName("KDAB");
     QApplication::setApplicationName("knut");
-    QApplication::setApplicationVersion(KNUT_VERSION_STRING);
+    QApplication::setApplicationVersion(core::knut_version());
     QApplication::setWindowIcon(QIcon(":/gui/icons/knut-64.png"));
 
     Q_INIT_RESOURCE(core);


### PR DESCRIPTION
We should be able to speed up our CI by caching the build artifacts using sccache like we do in [https://github.com/KDAB/cxx-qt/](CXX-Qt).
My goal is to stick below 10 min. CI build if at all possible.

Part of #3 