### PR TITLE
chore: move to C++20

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ project(
 
 # Project initialization
 # ##############################################################################
-set(CMAKE_CXX_STANDARD 23)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin")


### PR DESCRIPTION
Our current CI partially support C++23, but is limited.
For example std::unexpected is not supported yet.

Revert to using C++20 only for now, until CI is updated.