### PR TITLE
docs: Add link to our YouTube channel

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -28,3 +28,4 @@ Stay up-to-date with KDAB product announcements:
 * [KDAB Newsletter](https://news.kdab.com)
 * [KDAB Blogs](https://www.kdab.com/category/blogs)
 * [KDAB on Twitter](https://twitter.com/KDABQt)
+* [KDAB on YouTube](https://www.youtube.com/@KDABtv)


### PR DESCRIPTION
This is mostly meant to test our Documentation automation, but is also a valid addition