### PR TITLE
ci: Remove the reference to base_ref in docs job

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -11,8 +11,6 @@ on:
 
 jobs:
   mkdocs:
-    # Ensure that the tag was from the main branch and not a backport
-    if: github.event.base_ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
This is only available if the run is triggered by a Pull Request.