### PR TITLE
feat: add option to return the settings from the CLI

### DIFF
--- a/docs/getting-started/cli.md
+++ b/docs/getting-started/cli.md
@@ -9,15 +9,19 @@ knut [option] [project]
 
 The `project` is the directory containing the source code you want to work on. All available options are documented here:
 
-| Options | Description |
-|-|-|
-|-r, --run `<file>` | Runs given script `<file>` then exit|
-|-t, --test `<file>` | Tests given script `<file>` then exit|
-|-i, --input `<file>` | Opens document `<file>` on startup|
-|-l, --line `<line>` | Sets the line in the current file, if any|
-|-c, --column `<column>` | Sets the column in the current file, if any|
-|--gui-run | Opens the run script dialog|
-|--gui-settings | Opens the settings dialog|
+| Options                 | Description                                              |
+| ----------------------- | -------------------------------------------------------- |
+| -r, --run `<file>`      | Runs given script `<file>` then exit                     |
+| -t, --test `<file>`     | Tests given script `<file>` then exit                    |
+| -i, --input `<file>`    | Opens document `<file>` on startup                       |
+| -l, --line `<line>`     | Sets the line in the current file, if any                |
+| -c, --column `<column>` | Sets the column in the current file, if any              |
+| --gui-run               | Opens the run script dialog                              |
+| --gui-settings          | Opens the settings dialog                                |
+| --json-list             | Returns the list of all available scripts as a JSON file |
+| --json-settings         | Returns the settings as a JSON file                      |
+
+> Note: the json options are mainly used for integration with 3rd party, not meant to be used by user directly.
 
 Without any options, knut will start the user interface.
 

--- a/src/core/knutcore.cpp
+++ b/src/core/knutcore.cpp
@@ -51,8 +51,8 @@ void KnutCore::process(const QStringList &arguments)
     initParser(parser);
     parser.process(arguments);
 
-    const bool list = parser.isSet("json-list");
-    if (list) {
+    const bool jsonList = parser.isSet("json-list");
+    if (jsonList) {
         initialize(Settings::Mode::Cli);
         auto model = Core::ScriptManager::model();
         if (model->rowCount() == 0) {
@@ -68,6 +68,13 @@ void KnutCore::process(const QStringList &arguments)
             std::cout << outputJson.dump() << "\n";
         }
 
+        exit(0);
+    }
+
+    const bool jsonSettings = parser.isSet("json-settings");
+    if (jsonSettings) {
+        initialize(Settings::Mode::Cli);
+        std::cout << Core::Settings::instance()->dumpJson() << "\n";
         exit(0);
     }
 
@@ -147,7 +154,8 @@ void KnutCore::initParser(QCommandLineParser &parser) const
                        {{"i", "input"}, "Opens document <file> on startup.", "file"},
                        {{"l", "line"}, "Line in the current file, if any.", "line"},
                        {{"c", "column"}, "Column in the current file, if any.", "column"},
-                       {"json-list", "Lists all available scripts"}});
+                       {"json-list", "Returns the list of all available scripts as a JSON file"},
+                       {"json-settings", "Returns the settings as a JSON file"}});
 }
 
 void KnutCore::doParse(const QCommandLineParser &parser) const

--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -302,6 +302,11 @@ void Settings::removeScriptPath(const QString &path)
     updatePaths(path, ScriptPaths, false);
 }
 
+std::string Settings::dumpJson() const
+{
+    return m_settings.dump();
+}
+
 void Settings::updatePaths(const QString &path, const std::string &json_path, bool add)
 {
     const auto pathPointer = nlohmann::json::json_pointer(json_path);

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -63,6 +63,8 @@ public:
     void addScriptPath(const QString &path);
     void removeScriptPath(const QString &path);
 
+    [[nodiscard]] std::string dumpJson() const;
+
     template <typename T>
     T value(std::string path) const
     {


### PR DESCRIPTION
The settings are returned as a json file, that could then be used by 3rdparty.

Original Author: Matt Aber (sorry, I messed up with git)

Fix #35