### PR TITLE
docs: Cleanup documentation

### DIFF
--- a/docs/API/script.test/testcase.md
+++ b/docs/API/script.test/testcase.md
@@ -6,10 +6,6 @@ Provides a way to create unit tests as script. [More...](#detailed-description)
 import Script.Test 1.0
 ```
 
-<table>
-<tr><td>Since:</td><td>Knut 1.0</td></tr>
-</table>
-
 ## Properties
 
 | | Name |

--- a/docs/API/script.test/testutil.md
+++ b/docs/API/script.test/testutil.md
@@ -6,10 +6,6 @@ Provides utility methods useful for testing. [More...](#detailed-description)
 import Script.Test 1.0
 ```
 
-<table>
-<tr><td>Since:</td><td>Knut 1.0</td></tr>
-</table>
-
 ## Methods
 
 | | Name |

--- a/docs/API/script/action.md
+++ b/docs/API/script/action.md
@@ -6,10 +6,6 @@ Description of a RC file action. [More...](#detailed-description)
 import Script 1.0
 ```
 
-<table>
-<tr><td>Since:</td><td>Knut 1.0</td></tr>
-</table>
-
 ## Properties
 
 | | Name |

--- a/docs/API/script/asset.md
+++ b/docs/API/script/asset.md
@@ -6,10 +6,6 @@ Description of a RC file asset. [More...](#detailed-description)
 import Script 1.0
 ```
 
-<table>
-<tr><td>Since:</td><td>Knut 1.0</td></tr>
-</table>
-
 ## Properties
 
 | | Name |

--- a/docs/API/script/classsymbol.md
+++ b/docs/API/script/classsymbol.md
@@ -10,10 +10,6 @@ Represents a class in the current file [More...](#detailed-description)
 import Script 1.0
 ```
 
-<table>
-<tr><td>Since:</td><td>Knut 1.0</td></tr>
-</table>
-
 ## Properties
 
 | | Name |

--- a/docs/API/script/codedocument.md
+++ b/docs/API/script/codedocument.md
@@ -6,11 +6,6 @@ Base document object for any code that Knut can parse. [More...](#detailed-descr
 import Script 1.0
 ```
 
-<table>
-<tr><td>Since:</td><td>Knut 1.0</td></tr>
-<tr><td>Inherits:</td><td><a href="TextDocument.html">TextDocument</a></td></tr>
-</table>
-
 ## Properties
 
 

--- a/docs/API/script/cppdocument.md
+++ b/docs/API/script/cppdocument.md
@@ -6,11 +6,6 @@ Document object for a C++ file (source or header) [More...](#detailed-descriptio
 import Script 1.0
 ```
 
-<table>
-<tr><td>Since:</td><td>Knut 1.0</td></tr>
-<tr><td>Inherits:</td><td><a href="CodeDocument.html">CodeDocument</a></td></tr>
-</table>
-
 ## Properties
 
 | | Name |

--- a/docs/API/script/dir.md
+++ b/docs/API/script/dir.md
@@ -6,10 +6,6 @@ Singleton with methods to handle directories. [More...](#detailed-description)
 import Script 1.0
 ```
 
-<table>
-<tr><td>Since:</td><td>Knut 1.0</td></tr>
-</table>
-
 ## Properties
 
 | | Name |

--- a/docs/API/script/document.md
+++ b/docs/API/script/document.md
@@ -6,10 +6,6 @@ Base class for all documents [More...](#detailed-description)
 import Script 1.0
 ```
 
-<table>
-<tr><td>Since:</td><td>Knut 1.0</td></tr>
-</table>
-
 ## Properties
 
 | | Name |

--- a/docs/API/script/file.md
+++ b/docs/API/script/file.md
@@ -6,10 +6,6 @@ Singleton with methods to handle files. [More...](#detailed-description)
 import Script 1.0
 ```
 
-<table>
-<tr><td>Since:</td><td>Knut 1.0</td></tr>
-</table>
-
 ## Methods
 
 | | Name |

--- a/docs/API/script/fileinfo.md
+++ b/docs/API/script/fileinfo.md
@@ -6,10 +6,6 @@ Singleton with methods to handle file information. [More...](#detailed-descripti
 import Script 1.0
 ```
 
-<table>
-<tr><td>Since:</td><td>Knut 1.0</td></tr>
-</table>
-
 ## Methods
 
 | | Name |

--- a/docs/API/script/functionargument.md
+++ b/docs/API/script/functionargument.md
@@ -10,10 +10,6 @@ Represents an argument to be passed to the function [More...](#detailed-descript
 import Script 1.0
 ```
 
-<table>
-<tr><td>Since:</td><td>Knut 1.0</td></tr>
-</table>
-
 ## Properties
 
 | | Name |

--- a/docs/API/script/functionsymbol.md
+++ b/docs/API/script/functionsymbol.md
@@ -10,10 +10,6 @@ Represents a function or a method in the current file [More...](#detailed-descri
 import Script 1.0
 ```
 
-<table>
-<tr><td>Since:</td><td>Knut 1.0</td></tr>
-</table>
-
 ## Properties
 
 | | Name |

--- a/docs/API/script/mark.md
+++ b/docs/API/script/mark.md
@@ -6,10 +6,6 @@ Keeps track of a position in a text document. [More...](#detailed-description)
 import Script 1.0
 ```
 
-<table>
-<tr><td>Since:</td><td>Knut 1.0</td></tr>
-</table>
-
 ## Properties
 
 | | Name |

--- a/docs/API/script/menu.md
+++ b/docs/API/script/menu.md
@@ -6,10 +6,6 @@ Description of a RC file menu. [More...](#detailed-description)
 import Script 1.0
 ```
 
-<table>
-<tr><td>Since:</td><td>Knut 1.0</td></tr>
-</table>
-
 ## Properties
 
 | | Name |

--- a/docs/API/script/menuitem.md
+++ b/docs/API/script/menuitem.md
@@ -6,10 +6,6 @@ Description of a RC file menu item. [More...](#detailed-description)
 import Script 1.0
 ```
 
-<table>
-<tr><td>Since:</td><td>Knut 1.0</td></tr>
-</table>
-
 ## Properties
 
 | | Name |

--- a/docs/API/script/message.md
+++ b/docs/API/script/message.md
@@ -6,10 +6,6 @@ Singleton with methods to display different messages to the user. [More...](#det
 import Script 1.0
 ```
 
-<table>
-<tr><td>Since:</td><td>Knut 1.0</td></tr>
-</table>
-
 ## Methods
 
 | | Name |

--- a/docs/API/script/project.md
+++ b/docs/API/script/project.md
@@ -6,10 +6,6 @@ Singleton for handling the current project. [More...](#detailed-description)
 import Script 1.0
 ```
 
-<table>
-<tr><td>Since:</td><td>Knut 1.0</td></tr>
-</table>
-
 ## Properties
 
 | | Name |

--- a/docs/API/script/qdirvaluetype.md
+++ b/docs/API/script/qdirvaluetype.md
@@ -6,10 +6,6 @@ Wrapper around the `QDir` class. [More...](#detailed-description)
 import Script 1.0
 ```
 
-<table>
-<tr><td>Since:</td><td>Knut 1.0</td></tr>
-</table>
-
 ## Properties
 
 | | Name |

--- a/docs/API/script/qfileinfovaluetype.md
+++ b/docs/API/script/qfileinfovaluetype.md
@@ -6,10 +6,6 @@ Wrapper around the `QFileInfo` class. [More...](#detailed-description)
 import Script 1.0
 ```
 
-<table>
-<tr><td>Since:</td><td>Knut 1.0</td></tr>
-</table>
-
 ## Properties
 
 | | Name |

--- a/docs/API/script/qttsdocument.md
+++ b/docs/API/script/qttsdocument.md
@@ -6,10 +6,6 @@ Provides access to the content of a Ts file (Qt linguist). [More...](#detailed-d
 import Script 1.0
 ```
 
-<table>
-<tr><td>Since:</td><td>Knut 1.0</td></tr>
-</table>
-
 ## Properties
 
 | | Name |

--- a/docs/API/script/qttsmessage.md
+++ b/docs/API/script/qttsmessage.md
@@ -6,10 +6,6 @@ Provides access to message. [More...](#detailed-description)
 import Script 1.0
 ```
 
-<table>
-<tr><td>Since:</td><td>Knut 1.0</td></tr>
-</table>
-
 ## Properties
 
 | | Name |

--- a/docs/API/script/qtuidocument.md
+++ b/docs/API/script/qtuidocument.md
@@ -6,10 +6,6 @@ Provides access to the content of a Ui file (Qt designer file). [More...](#detai
 import Script 1.0
 ```
 
-<table>
-<tr><td>Since:</td><td>Knut 1.0</td></tr>
-</table>
-
 ## Properties
 
 | | Name |

--- a/docs/API/script/qtuiwidget.md
+++ b/docs/API/script/qtuiwidget.md
@@ -6,10 +6,6 @@ Provides access to widget attributes in the ui files. [More...](#detailed-descri
 import Script 1.0
 ```
 
-<table>
-<tr><td>Since:</td><td>Knut 1.0</td></tr>
-</table>
-
 ## Properties
 
 | | Name |

--- a/docs/API/script/rcdocument.md
+++ b/docs/API/script/rcdocument.md
@@ -6,10 +6,6 @@ Provides access to the content of a RC file (MFC resource file). [More...](#deta
 import Script 1.0
 ```
 
-<table>
-<tr><td>Since:</td><td>Knut 1.0</td></tr>
-</table>
-
 ## Properties
 
 | | Name |

--- a/docs/API/script/ribbon.md
+++ b/docs/API/script/ribbon.md
@@ -6,10 +6,6 @@ The ribbon description (not everything is read yet). [More...](#detailed-descrip
 import Script 1.0
 ```
 
-<table>
-<tr><td>Since:</td><td>Knut 1.0</td></tr>
-</table>
-
 ## Properties
 
 | | Name |

--- a/docs/API/script/ribboncategory.md
+++ b/docs/API/script/ribboncategory.md
@@ -6,10 +6,6 @@ A tab (made of panels) in the ribbon. [More...](#detailed-description)
 import Script 1.0
 ```
 
-<table>
-<tr><td>Since:</td><td>Knut 1.0</td></tr>
-</table>
-
 ## Properties
 
 | | Name |

--- a/docs/API/script/ribboncontext.md
+++ b/docs/API/script/ribboncontext.md
@@ -6,10 +6,6 @@ A context (tabs with a title) in the ribbon. [More...](#detailed-description)
 import Script 1.0
 ```
 
-<table>
-<tr><td>Since:</td><td>Knut 1.0</td></tr>
-</table>
-
 ## Properties
 
 | | Name |

--- a/docs/API/script/ribbonelement.md
+++ b/docs/API/script/ribbonelement.md
@@ -6,10 +6,6 @@ An item in the ribbon (button, separator...). [More...](#detailed-description)
 import Script 1.0
 ```
 
-<table>
-<tr><td>Since:</td><td>Knut 1.0</td></tr>
-</table>
-
 ## Properties
 
 | | Name |

--- a/docs/API/script/ribbonmenu.md
+++ b/docs/API/script/ribbonmenu.md
@@ -6,10 +6,6 @@ A menu showing when clicking on the left/top icon in the ribbon. [More...](#deta
 import Script 1.0
 ```
 
-<table>
-<tr><td>Since:</td><td>Knut 1.0</td></tr>
-</table>
-
 ## Properties
 
 | | Name |

--- a/docs/API/script/ribbonpanel.md
+++ b/docs/API/script/ribbonpanel.md
@@ -6,10 +6,6 @@ An panel (group of elements) in the ribbon. [More...](#detailed-description)
 import Script 1.0
 ```
 
-<table>
-<tr><td>Since:</td><td>Knut 1.0</td></tr>
-</table>
-
 ## Properties
 
 | | Name |

--- a/docs/API/script/script.md
+++ b/docs/API/script/script.md
@@ -6,10 +6,6 @@ Script object for writing non visual scripts. [More...](#detailed-description)
 import Script 1.0
 ```
 
-<table>
-<tr><td>Since:</td><td>Knut 1.0</td></tr>
-</table>
-
 ## Detailed Description
 
 The `Script` is the base class for all creatable items in QML. It is needed as a `QtObject`

--- a/docs/API/script/scriptdialog.md
+++ b/docs/API/script/scriptdialog.md
@@ -6,10 +6,6 @@ QML Item for writing visual scripts. [More...](#detailed-description)
 import Script 1.0
 ```
 
-<table>
-<tr><td>Since:</td><td>Knut 1.0</td></tr>
-</table>
-
 ## Properties
 
 | | Name |

--- a/docs/API/script/settings.md
+++ b/docs/API/script/settings.md
@@ -6,10 +6,6 @@ Singleton for accessing and editing persistent settings. [More...](#detailed-des
 import Script 1.0
 ```
 
-<table>
-<tr><td>Since:</td><td>Knut 1.0</td></tr>
-</table>
-
 ## Properties
 
 | | Name |

--- a/docs/API/script/shortcut.md
+++ b/docs/API/script/shortcut.md
@@ -6,10 +6,6 @@ Description of a RC file shortcut. [More...](#detailed-description)
 import Script 1.0
 ```
 
-<table>
-<tr><td>Since:</td><td>Knut 1.0</td></tr>
-</table>
-
 ## Properties
 
 | | Name |

--- a/docs/API/script/string.md
+++ b/docs/API/script/string.md
@@ -6,10 +6,6 @@ Description of a RC file string. [More...](#detailed-description)
 import Script 1.0
 ```
 
-<table>
-<tr><td>Since:</td><td>Knut 1.0</td></tr>
-</table>
-
 ## Properties
 
 | | Name |

--- a/docs/API/script/symbol.md
+++ b/docs/API/script/symbol.md
@@ -6,10 +6,6 @@ Represent a symbol in the current file [More...](#detailed-description)
 import Script 1.0
 ```
 
-<table>
-<tr><td>Since:</td><td>Knut 1.0</td></tr>
-</table>
-
 ## Properties
 
 | | Name |

--- a/docs/API/script/textdocument.md
+++ b/docs/API/script/textdocument.md
@@ -6,11 +6,6 @@ Document object for text files. [More...](#detailed-description)
 import Script 1.0
 ```
 
-<table>
-<tr><td>Since:</td><td>Knut 1.0</td></tr>
-<tr><td>Inherits:</td><td><a href="Document.html">Document</a></td></tr>
-</table>
-
 ## Properties
 
 | | Name |

--- a/docs/API/script/textrange.md
+++ b/docs/API/script/textrange.md
@@ -6,10 +6,6 @@ Defines a range of text in a text document [More...](#detailed-description)
 import Script 1.0
 ```
 
-<table>
-<tr><td>Since:</td><td>Knut 1.0</td></tr>
-</table>
-
 ## Properties
 
 | | Name |

--- a/docs/API/script/toolbar.md
+++ b/docs/API/script/toolbar.md
@@ -6,10 +6,6 @@ Description of a RC file toolbar. [More...](#detailed-description)
 import Script 1.0
 ```
 
-<table>
-<tr><td>Since:</td><td>Knut 1.0</td></tr>
-</table>
-
 ## Properties
 
 | | Name |

--- a/docs/API/script/toolbaritem.md
+++ b/docs/API/script/toolbaritem.md
@@ -6,10 +6,6 @@ Description of a RC file toolbar item. [More...](#detailed-description)
 import Script 1.0
 ```
 
-<table>
-<tr><td>Since:</td><td>Knut 1.0</td></tr>
-</table>
-
 ## Properties
 
 | | Name |

--- a/docs/API/script/userdialog.md
+++ b/docs/API/script/userdialog.md
@@ -6,10 +6,6 @@ Singleton with methods to display common dialog to the user. [More...](#detailed
 import Script 1.0
 ```
 
-<table>
-<tr><td>Since:</td><td>Knut 1.0</td></tr>
-</table>
-
 ## Methods
 
 | | Name |

--- a/docs/API/script/utils.md
+++ b/docs/API/script/utils.md
@@ -6,10 +6,6 @@ Singleton with utility methods. [More...](#detailed-description)
 import Script 1.0
 ```
 
-<table>
-<tr><td>Since:</td><td>Knut 1.0</td></tr>
-</table>
-
 ## Methods
 
 | | Name |

--- a/docs/API/script/widget.md
+++ b/docs/API/script/widget.md
@@ -6,10 +6,6 @@ Description of a RC file widget. [More...](#detailed-description)
 import Script 1.0
 ```
 
-<table>
-<tr><td>Since:</td><td>Knut 1.0</td></tr>
-</table>
-
 ## Properties
 
 | | Name |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,7 @@
-site_name: Knut v1.0
+site_name: Knut - Code transformation via scripts
 site_description: Knut Documentation - Automation tool for code transformation using scripts
 site_author: Klarälvdalens Datakonsult AB (KDAB)
-site_url: https://docs.kdab.com/knut/latest/
+site_url: https://kdab.github.io/knut/
 copyright: "Copyright &copy; Klar&auml;lvdalens Datakonsult AB (KDAB)<br>Trusted Software Excellence<br><a href='https://www.kdab.com'>https://www.kdab.com/</a>"
 repo_url: https://github.com/KDAB/Knut
 repo_name: Knut

--- a/src/core/classsymbol.cpp
+++ b/src/core/classsymbol.cpp
@@ -21,7 +21,6 @@ namespace Core {
  * \brief Represents a class in the current file
  * \inqmlmodule Script
  * \ingroup CodeDocument
- * \since 1.0
  * \todo
  */
 /*!

--- a/src/core/codedocument.cpp
+++ b/src/core/codedocument.cpp
@@ -40,7 +40,6 @@ namespace Core {
  * \brief Base document object for any code that Knut can parse.
  * \inqmlmodule Script
  * \ingroup CodeDocument/@first
- * \since 1.0
  * \inherits TextDocument
  *
  * Knut uses Tree-sitter to parse the code and provide additional information about it.

--- a/src/core/cppdocument.cpp
+++ b/src/core/cppdocument.cpp
@@ -34,7 +34,6 @@ namespace Core {
  * \brief Document object for a C++ file (source or header)
  * \inqmlmodule Script
  * \ingroup CppDocument/@first
- * \since 1.0
  * \inherits CodeDocument
  */
 

--- a/src/core/dir.cpp
+++ b/src/core/dir.cpp
@@ -20,7 +20,6 @@ namespace Core {
  * \brief Singleton with methods to handle directories.
  * \inqmlmodule Script
  * \ingroup Utilities
- * \since 1.0
  *
  * The `Dir` singleton implements most of the static methods from `QDir`, check [QDir](https://doc.qt.io/qt-5/qdir.html)
  * documentation.

--- a/src/core/document.cpp
+++ b/src/core/document.cpp
@@ -24,7 +24,6 @@ namespace Core {
  * \qmltype Document
  * \brief Base class for all documents
  * \inqmlmodule Script
- * \since 1.0
  *
  * The `Document` class is the base class for all documents.
  * A document is a file loaded by Knut and that can be used in script (either to get data or to edit).

--- a/src/core/file.cpp
+++ b/src/core/file.cpp
@@ -21,7 +21,6 @@ namespace Core {
  * \brief Singleton with methods to handle files.
  * \inqmlmodule Script
  * \ingroup Utilities
- * \since 1.0
  *
  * The `File` singleton implements most of the static methods from `QFile`, check
  * [QFile](https://doc.qt.io/qt-5/qfile.html) documentation.

--- a/src/core/fileinfo.cpp
+++ b/src/core/fileinfo.cpp
@@ -20,7 +20,6 @@ namespace Core {
  * \brief Singleton with methods to handle file information.
  * \inqmlmodule Script
  * \ingroup Utilities
- * \since 1.0
  *
  * The `FileInfo` singleton implements most of the static methods from `QFileInfo`, check
  * [QFileInfo](https://doc.qt.io/qt-5/qfileinfo.html) documentation.

--- a/src/core/functionsymbol.cpp
+++ b/src/core/functionsymbol.cpp
@@ -23,7 +23,6 @@ namespace Core {
  * \brief Represents an argument to be passed to the function
  * \inqmlmodule Script
  * \ingroup CodeDocument
- * \since 1.0
  * \todo
  * \sa FunctionSymbol
  */
@@ -42,7 +41,6 @@ namespace Core {
  * \brief Represents a function or a method in the current file
  * \inqmlmodule Script
  * \ingroup CodeDocument
- * \since 1.0
  * \todo
  */
 

--- a/src/core/mark.cpp
+++ b/src/core/mark.cpp
@@ -24,7 +24,6 @@ namespace Core {
  * \brief Keeps track of a position in a text document.
  * \inqmlmodule Script
  * \ingroup TextDocument
- * \since 1.0
  * \sa TextDocument
  *
  * The Mark object helps you track a logical position in a file.

--- a/src/core/message.cpp
+++ b/src/core/message.cpp
@@ -20,7 +20,6 @@ namespace Core {
  * \brief Singleton with methods to display different messages to the user.
  * \inqmlmodule Script
  * \ingroup Utilities
- * \since 1.0
  *
  * The `message` property in QML can be used to display different messages to the user, via logs.
  *

--- a/src/core/project.cpp
+++ b/src/core/project.cpp
@@ -39,7 +39,6 @@ namespace Core {
  * \qmltype Project
  * \brief Singleton for handling the current project.
  * \inqmlmodule Script
- * \since 1.0
  * The `Project` object is not meant to open multiple projects, but only open one.
  */
 

--- a/src/core/qdirvaluetype.cpp
+++ b/src/core/qdirvaluetype.cpp
@@ -18,7 +18,6 @@ namespace Core {
  * \inqmlmodule Script
  * \ingroup Utilities/@last
  * \sa Dir
- * \since 1.0
  *
  * The `QDirValueType` is a wrapper around the `QDir` C++ class, check [QDir](https://doc.qt.io/qt-5/qdir.html)
  * documentation. It can only be created using [Dir](dir.md) singleton.

--- a/src/core/qfileinfovaluetype.cpp
+++ b/src/core/qfileinfovaluetype.cpp
@@ -18,7 +18,6 @@ namespace Core {
  * \inqmlmodule Script
  * \ingroup Utilities/@last
  * \sa FileInfo
- * \since 1.0
  *
  * The `QFileInfoValueType` is a wrapper around the `QFileInfo` C++ class, check
  * [QFileInfo](https://doc.qt.io/qt-5/qfileinfo.html) documentation. It can only be created using

--- a/src/core/qml/Script/Test/TestCase.qml
+++ b/src/core/qml/Script/Test/TestCase.qml
@@ -6,7 +6,6 @@ import Script.Test 1.0
  * \qmltype TestCase
  * \brief Provides a way to create unit tests as script.
  * \inqmlmodule Script.Test
- * \since 1.0
  * Run unit tests as a script, and returns the number of failed tests.
  */
 

--- a/src/core/qttsdocument.cpp
+++ b/src/core/qttsdocument.cpp
@@ -24,7 +24,6 @@ namespace Core {
  * \brief Provides access to the content of a Ts file (Qt linguist).
  * \inqmlmodule Script
  * \ingroup QtTsDocument/@first
- * \since 1.0
  */
 
 /*!
@@ -219,7 +218,6 @@ QVector<QtTsMessage *> QtTsDocument::messages() const
  * \brief Provides access to message.
  * \inqmlmodule Script
  * \ingroup QtTsDocument
- * \since 1.0
  * \sa QtTsDocument
  */
 

--- a/src/core/qtuidocument.cpp
+++ b/src/core/qtuidocument.cpp
@@ -24,7 +24,6 @@ namespace Core {
  * \brief Provides access to the content of a Ui file (Qt designer file).
  * \inqmlmodule Script
  * \ingroup QtUiDocument/@first
- * \since 1.0
  */
 
 /*!
@@ -104,7 +103,6 @@ bool QtUiDocument::doLoad(const QString &fileName)
  * \brief Provides access to widget attributes in the ui files.
  * \inqmlmodule Script
  * \ingroup QtUiDocument
- * \since 1.0
  * \sa QtUiDocument
  */
 

--- a/src/core/rcdocument.cpp
+++ b/src/core/rcdocument.cpp
@@ -26,7 +26,6 @@ namespace Core {
  * \brief Provides access to the content of a RC file (MFC resource file).
  * \inqmlmodule Script
  * \ingroup RcDocument/@first
- * \since 1.0
  */
 
 /*!

--- a/src/core/scriptdialogitem.cpp
+++ b/src/core/scriptdialogitem.cpp
@@ -41,7 +41,6 @@ namespace Core {
  * \brief QML Item for writing visual scripts.
  * \inqmlmodule Script
  * \ingroup Items
- * \since 1.0
  *
  * The `ScriptDialog` allows creating a script dialog based on a ui file. It requires creating a ui file with the same
  * name as the qml script.

--- a/src/core/scriptitem.cpp
+++ b/src/core/scriptitem.cpp
@@ -17,7 +17,6 @@ namespace Core {
  * \brief Script object for writing non visual scripts.
  * \inqmlmodule Script
  * \ingroup Items
- * \since 1.0
  *
  * The `Script` is the base class for all creatable items in QML. It is needed as a `QtObject`
  * can't have any children in QML. It can be used as the basis for non visual QML scripts:

--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -52,7 +52,6 @@ static constexpr char SettingsName[] = "knut.json";
  * \brief Singleton for accessing and editing persistent settings.
  * \inqmlmodule Script
  * \ingroup Utilities
- * \since 1.0
  *
  * The settings are stored in a json file, and could be:
  *

--- a/src/core/symbol.cpp
+++ b/src/core/symbol.cpp
@@ -25,7 +25,6 @@ namespace Core {
  * \brief Represent a symbol in the current file
  * \inqmlmodule Script
  * \ingroup CodeDocument
- * \since 1.0
  */
 
 /*!

--- a/src/core/testutil.cpp
+++ b/src/core/testutil.cpp
@@ -23,7 +23,6 @@ namespace Core {
  * \qmltype TestUtil
  * \brief Provides utility methods useful for testing.
  * \inqmlmodule Script.Test
- * \since 1.0
  *
  * This class is mainly used by the [TestCase](testcase.md) object, to extract some information on the script.
  *

--- a/src/core/textdocument.cpp
+++ b/src/core/textdocument.cpp
@@ -68,7 +68,6 @@ matchInBlock(const QTextBlock &block, const QRegularExpression &expr, int offset
  * \brief Document object for text files.
  * \inqmlmodule Script
  * \ingroup TextDocument/@first
- * \since 1.0
  * \inherits Document
  */
 /*!

--- a/src/core/textrange.cpp
+++ b/src/core/textrange.cpp
@@ -17,7 +17,6 @@ namespace Core {
  * \brief Defines a range of text in a text document
  * \inqmlmodule Script
  * \ingroup TextDocument
- * \since 1.0
  * \sa TextDocument
  */
 /*!

--- a/src/core/userdialog.cpp
+++ b/src/core/userdialog.cpp
@@ -23,7 +23,6 @@ namespace Core {
  * \brief Singleton with methods to display common dialog to the user.
  * \inqmlmodule Script
  * \ingroup Utilities
- * \since 1.0
  *
  * The `UserDialog` singleton provides methods to display common dialog that could be used in
  * scripts. If the user cancel the dialog, it will return a null value you can test directly:

--- a/src/core/utils.cpp
+++ b/src/core/utils.cpp
@@ -27,7 +27,6 @@ namespace Core {
  * \brief Singleton with utility methods.
  * \inqmlmodule Script
  * \ingroup Utilities
- * \since 1.0
  *
  * The `Utils` singleton implements some utility methods useful for scripts.
  */

--- a/src/rccore/data.cpp
+++ b/src/rccore/data.cpp
@@ -18,7 +18,6 @@ namespace RcCore {
  * \brief Description of a RC file asset.
  * \inqmlmodule Script
  * \ingroup RcDocument
- * \since 1.0
  * \sa RcFile
  */
 /*!
@@ -40,7 +39,6 @@ namespace RcCore {
  * \brief Description of a RC file toolbar item.
  * \inqmlmodule Script
  * \ingroup RcDocument
- * \since 1.0
  * \sa RcFile
  */
 /*!
@@ -57,7 +55,6 @@ namespace RcCore {
  * \brief Description of a RC file toolbar.
  * \inqmlmodule Script
  * \ingroup RcDocument
- * \since 1.0
  * \sa RcFile
  */
 /*!
@@ -82,7 +79,6 @@ namespace RcCore {
  * \brief Description of a RC file widget.
  * \inqmlmodule Script
  * \ingroup RcDocument
- * \since 1.0
  * \sa RcFile
  */
 /*!
@@ -115,7 +111,6 @@ namespace RcCore {
  * \brief Description of a RC file menu item.
  * \inqmlmodule Script
  * \ingroup RcDocument
- * \since 1.0
  * \sa RcFile
  */
 /*!
@@ -148,7 +143,6 @@ namespace RcCore {
  * \brief Description of a RC file menu.
  * \inqmlmodule Script
  * \ingroup RcDocument
- * \since 1.0
  * \sa RcFile
  */
 /*!
@@ -169,7 +163,6 @@ namespace RcCore {
  * \brief Description of a RC file shortcut.
  * \inqmlmodule Script
  * \ingroup RcDocument
- * \since 1.0
  * \sa RcFile
  */
 /*!
@@ -186,7 +179,6 @@ namespace RcCore {
  * \brief Description of a RC file action.
  * \inqmlmodule Script
  * \ingroup RcDocument
- * \since 1.0
  * \sa RcFile
  */
 /*!
@@ -219,7 +211,6 @@ namespace RcCore {
  * \brief Description of a RC file string.
  * \inqmlmodule Script
  * \ingroup RcDocument
- * \since 1.0
  * \sa RcFile
  */
 /*!

--- a/src/rccore/ribbon.cpp
+++ b/src/rccore/ribbon.cpp
@@ -19,7 +19,6 @@ namespace RcCore {
  * \brief An item in the ribbon (button, separator...).
  * \inqmlmodule Script
  * \ingroup RcDocument
- * \since 1.0
  * \sa Ribbon
  */
 /*!
@@ -60,7 +59,6 @@ namespace RcCore {
  * \brief An panel (group of elements) in the ribbon.
  * \inqmlmodule Script
  * \ingroup RcDocument
- * \since 1.0
  * \sa Ribbon
  */
 /*!
@@ -81,7 +79,6 @@ namespace RcCore {
  * \brief A tab (made of panels) in the ribbon.
  * \inqmlmodule Script
  * \ingroup RcDocument
- * \since 1.0
  * \sa Ribbon
  */
 /*!
@@ -110,7 +107,6 @@ namespace RcCore {
  * \brief A context (tabs with a title) in the ribbon.
  * \inqmlmodule Script
  * \ingroup RcDocument
- * \since 1.0
  * \sa Ribbon
  */
 /*!
@@ -131,7 +127,6 @@ namespace RcCore {
  * \brief A menu showing when clicking on the left/top icon in the ribbon.
  * \inqmlmodule Script
  * \ingroup RcDocument
- * \since 1.0
  * \sa Ribbon
  */
 /*!
@@ -160,7 +155,6 @@ namespace RcCore {
  * \brief The ribbon description (not everything is read yet).
  * \inqmlmodule Script
  * \ingroup RcDocument
- * \since 1.0
  * \sa RcFile
  *
  * A ribbon is made of multiple items:


### PR DESCRIPTION
- Remove v1.0 from documentation title (it's just the latest)
- Remove since 1.0, this doesn't make sense