### PR TITLE
Remove version from import

### DIFF
--- a/docs/API/script.test/testcase.md
+++ b/docs/API/script.test/testcase.md
@@ -3,7 +3,7 @@
 Provides a way to create unit tests as script. [More...](#detailed-description)
 
 ```qml
-import Script.Test 1.0
+import Script.Test
 ```
 
 ## Properties

--- a/docs/API/script.test/testutil.md
+++ b/docs/API/script.test/testutil.md
@@ -3,7 +3,7 @@
 Provides utility methods useful for testing. [More...](#detailed-description)
 
 ```qml
-import Script.Test 1.0
+import Script.Test
 ```
 
 ## Methods

--- a/docs/API/script/action.md
+++ b/docs/API/script/action.md
@@ -3,7 +3,7 @@
 Description of a RC file action. [More...](#detailed-description)
 
 ```qml
-import Script 1.0
+import Script
 ```
 
 ## Properties

--- a/docs/API/script/asset.md
+++ b/docs/API/script/asset.md
@@ -3,7 +3,7 @@
 Description of a RC file asset. [More...](#detailed-description)
 
 ```qml
-import Script 1.0
+import Script
 ```
 
 ## Properties

--- a/docs/API/script/classsymbol.md
+++ b/docs/API/script/classsymbol.md
@@ -7,7 +7,7 @@
 Represents a class in the current file [More...](#detailed-description)
 
 ```qml
-import Script 1.0
+import Script
 ```
 
 ## Properties

--- a/docs/API/script/codedocument.md
+++ b/docs/API/script/codedocument.md
@@ -3,7 +3,7 @@
 Base document object for any code that Knut can parse. [More...](#detailed-description)
 
 ```qml
-import Script 1.0
+import Script
 ```
 
 ## Properties

--- a/docs/API/script/cppdocument.md
+++ b/docs/API/script/cppdocument.md
@@ -3,7 +3,7 @@
 Document object for a C++ file (source or header) [More...](#detailed-description)
 
 ```qml
-import Script 1.0
+import Script
 ```
 
 ## Properties

--- a/docs/API/script/dataexchange.md
+++ b/docs/API/script/dataexchange.md
@@ -3,7 +3,7 @@
 DataExchange entries in a MFC C++ document. [More...](#detailed-description)
 
 ```qml
-import Script 1.0
+import Script
 ```
 
 ## Properties

--- a/docs/API/script/dataexchangeentry.md
+++ b/docs/API/script/dataexchangeentry.md
@@ -3,7 +3,7 @@
 Refers to a single entry within the `DoDataExchange` [More...](#detailed-description)
 
 ```qml
-import Script 1.0
+import Script
 ```
 
 ## Properties

--- a/docs/API/script/dir.md
+++ b/docs/API/script/dir.md
@@ -3,7 +3,7 @@
 Singleton with methods to handle directories. [More...](#detailed-description)
 
 ```qml
-import Script 1.0
+import Script
 ```
 
 ## Properties

--- a/docs/API/script/document.md
+++ b/docs/API/script/document.md
@@ -3,7 +3,7 @@
 Base class for all documents [More...](#detailed-description)
 
 ```qml
-import Script 1.0
+import Script
 ```
 
 ## Properties

--- a/docs/API/script/file.md
+++ b/docs/API/script/file.md
@@ -3,7 +3,7 @@
 Singleton with methods to handle files. [More...](#detailed-description)
 
 ```qml
-import Script 1.0
+import Script
 ```
 
 ## Methods

--- a/docs/API/script/fileinfo.md
+++ b/docs/API/script/fileinfo.md
@@ -3,7 +3,7 @@
 Singleton with methods to handle file information. [More...](#detailed-description)
 
 ```qml
-import Script 1.0
+import Script
 ```
 
 ## Methods

--- a/docs/API/script/functionargument.md
+++ b/docs/API/script/functionargument.md
@@ -7,7 +7,7 @@
 Represents an argument to be passed to the function [More...](#detailed-description)
 
 ```qml
-import Script 1.0
+import Script
 ```
 
 ## Properties

--- a/docs/API/script/functionsymbol.md
+++ b/docs/API/script/functionsymbol.md
@@ -7,7 +7,7 @@
 Represents a function or a method in the current file [More...](#detailed-description)
 
 ```qml
-import Script 1.0
+import Script
 ```
 
 ## Properties

--- a/docs/API/script/mark.md
+++ b/docs/API/script/mark.md
@@ -3,7 +3,7 @@
 Keeps track of a position in a text document. [More...](#detailed-description)
 
 ```qml
-import Script 1.0
+import Script
 ```
 
 ## Properties

--- a/docs/API/script/menu.md
+++ b/docs/API/script/menu.md
@@ -3,7 +3,7 @@
 Description of a RC file menu. [More...](#detailed-description)
 
 ```qml
-import Script 1.0
+import Script
 ```
 
 ## Properties

--- a/docs/API/script/menuitem.md
+++ b/docs/API/script/menuitem.md
@@ -3,7 +3,7 @@
 Description of a RC file menu item. [More...](#detailed-description)
 
 ```qml
-import Script 1.0
+import Script
 ```
 
 ## Properties

--- a/docs/API/script/message.md
+++ b/docs/API/script/message.md
@@ -3,7 +3,7 @@
 Singleton with methods to display different messages to the user. [More...](#detailed-description)
 
 ```qml
-import Script 1.0
+import Script
 ```
 
 ## Methods

--- a/docs/API/script/messagemap.md
+++ b/docs/API/script/messagemap.md
@@ -3,7 +3,7 @@
 Message map in a MFC C++ document [More...](#detailed-description)
 
 ```qml
-import Script 1.0
+import Script
 ```
 
 ## Properties

--- a/docs/API/script/messagemapentry.md
+++ b/docs/API/script/messagemapentry.md
@@ -3,7 +3,7 @@
 Refers to a single entry within the `MessageMap` [More...](#detailed-description)
 
 ```qml
-import Script 1.0
+import Script
 ```
 
 ## Properties

--- a/docs/API/script/project.md
+++ b/docs/API/script/project.md
@@ -3,7 +3,7 @@
 Singleton for handling the current project. [More...](#detailed-description)
 
 ```qml
-import Script 1.0
+import Script
 ```
 
 ## Properties

--- a/docs/API/script/qdirvaluetype.md
+++ b/docs/API/script/qdirvaluetype.md
@@ -3,7 +3,7 @@
 Wrapper around the `QDir` class. [More...](#detailed-description)
 
 ```qml
-import Script 1.0
+import Script
 ```
 
 ## Properties

--- a/docs/API/script/qfileinfovaluetype.md
+++ b/docs/API/script/qfileinfovaluetype.md
@@ -3,7 +3,7 @@
 Wrapper around the `QFileInfo` class. [More...](#detailed-description)
 
 ```qml
-import Script 1.0
+import Script
 ```
 
 ## Properties

--- a/docs/API/script/qttsdocument.md
+++ b/docs/API/script/qttsdocument.md
@@ -3,7 +3,7 @@
 Provides access to the content of a Ts file (Qt linguist). [More...](#detailed-description)
 
 ```qml
-import Script 1.0
+import Script
 ```
 
 ## Properties

--- a/docs/API/script/qttsmessage.md
+++ b/docs/API/script/qttsmessage.md
@@ -3,7 +3,7 @@
 Provides access to message. [More...](#detailed-description)
 
 ```qml
-import Script 1.0
+import Script
 ```
 
 ## Properties

--- a/docs/API/script/qtuidocument.md
+++ b/docs/API/script/qtuidocument.md
@@ -3,7 +3,7 @@
 Provides access to the content of a Ui file (Qt designer file). [More...](#detailed-description)
 
 ```qml
-import Script 1.0
+import Script
 ```
 
 ## Properties

--- a/docs/API/script/qtuiwidget.md
+++ b/docs/API/script/qtuiwidget.md
@@ -3,7 +3,7 @@
 Provides access to widget attributes in the ui files. [More...](#detailed-description)
 
 ```qml
-import Script 1.0
+import Script
 ```
 
 ## Properties

--- a/docs/API/script/querycapture.md
+++ b/docs/API/script/querycapture.md
@@ -3,7 +3,7 @@
 Defines a capture made by a query. [More...](#detailed-description)
 
 ```qml
-import Script 1.0
+import Script
 ```
 
 ## Properties

--- a/docs/API/script/querymatch.md
+++ b/docs/API/script/querymatch.md
@@ -3,7 +3,7 @@
 Contains all captures for a query match. [More...](#detailed-description)
 
 ```qml
-import Script 1.0
+import Script
 ```
 
 ## Properties

--- a/docs/API/script/rangemark.md
+++ b/docs/API/script/rangemark.md
@@ -3,7 +3,7 @@
 Keeps track of a range within a text document. [More...](#detailed-description)
 
 ```qml
-import Script 1.0
+import Script
 ```
 
 ## Properties

--- a/docs/API/script/rcdocument.md
+++ b/docs/API/script/rcdocument.md
@@ -3,7 +3,7 @@
 Provides access to the content of a RC file (MFC resource file). [More...](#detailed-description)
 
 ```qml
-import Script 1.0
+import Script
 ```
 
 ## Properties

--- a/docs/API/script/ribbon.md
+++ b/docs/API/script/ribbon.md
@@ -3,7 +3,7 @@
 The ribbon description (not everything is read yet). [More...](#detailed-description)
 
 ```qml
-import Script 1.0
+import Script
 ```
 
 ## Properties

--- a/docs/API/script/ribboncategory.md
+++ b/docs/API/script/ribboncategory.md
@@ -3,7 +3,7 @@
 A tab (made of panels) in the ribbon. [More...](#detailed-description)
 
 ```qml
-import Script 1.0
+import Script
 ```
 
 ## Properties

--- a/docs/API/script/ribboncontext.md
+++ b/docs/API/script/ribboncontext.md
@@ -3,7 +3,7 @@
 A context (tabs with a title) in the ribbon. [More...](#detailed-description)
 
 ```qml
-import Script 1.0
+import Script
 ```
 
 ## Properties

--- a/docs/API/script/ribbonelement.md
+++ b/docs/API/script/ribbonelement.md
@@ -3,7 +3,7 @@
 An item in the ribbon (button, separator...). [More...](#detailed-description)
 
 ```qml
-import Script 1.0
+import Script
 ```
 
 ## Properties

--- a/docs/API/script/ribbonmenu.md
+++ b/docs/API/script/ribbonmenu.md
@@ -3,7 +3,7 @@
 A menu showing when clicking on the left/top icon in the ribbon. [More...](#detailed-description)
 
 ```qml
-import Script 1.0
+import Script
 ```
 
 ## Properties

--- a/docs/API/script/ribbonpanel.md
+++ b/docs/API/script/ribbonpanel.md
@@ -3,7 +3,7 @@
 An panel (group of elements) in the ribbon. [More...](#detailed-description)
 
 ```qml
-import Script 1.0
+import Script
 ```
 
 ## Properties

--- a/docs/API/script/script.md
+++ b/docs/API/script/script.md
@@ -3,7 +3,7 @@
 Script object for writing non visual scripts. [More...](#detailed-description)
 
 ```qml
-import Script 1.0
+import Script
 ```
 
 ## Detailed Description
@@ -12,7 +12,7 @@ The `Script` is the base class for all creatable items in QML. It is needed as a
 can't have any children in QML. It can be used as the basis for non visual QML scripts:
 
 ```qml
-import Script 1.0
+import Script
 
 Script {
 // ...

--- a/docs/API/script/scriptdialog.md
+++ b/docs/API/script/scriptdialog.md
@@ -3,7 +3,7 @@
 QML Item for writing visual scripts. [More...](#detailed-description)
 
 ```qml
-import Script 1.0
+import Script
 ```
 
 ## Properties
@@ -41,7 +41,7 @@ Buttons (`QPushButton` or `QToolButton`) `clicked` signal is mapped to the `clic
 button `objectName` as parameter. `QDialogButtonBox` `accepted` or `rejected` signals are automatically connected.
 
 ```qml
-import Script 1.0
+import Script
 
 ScriptDialog {
     property string text1: data.lineEdit

--- a/docs/API/script/settings.md
+++ b/docs/API/script/settings.md
@@ -3,7 +3,7 @@
 Singleton for accessing and editing persistent settings. [More...](#detailed-description)
 
 ```qml
-import Script 1.0
+import Script
 ```
 
 ## Properties

--- a/docs/API/script/shortcut.md
+++ b/docs/API/script/shortcut.md
@@ -3,7 +3,7 @@
 Description of a RC file shortcut. [More...](#detailed-description)
 
 ```qml
-import Script 1.0
+import Script
 ```
 
 ## Properties

--- a/docs/API/script/string.md
+++ b/docs/API/script/string.md
@@ -3,7 +3,7 @@
 Description of a RC file string. [More...](#detailed-description)
 
 ```qml
-import Script 1.0
+import Script
 ```
 
 ## Properties

--- a/docs/API/script/symbol.md
+++ b/docs/API/script/symbol.md
@@ -3,7 +3,7 @@
 Represent a symbol in the current file [More...](#detailed-description)
 
 ```qml
-import Script 1.0
+import Script
 ```
 
 ## Properties

--- a/docs/API/script/textdocument.md
+++ b/docs/API/script/textdocument.md
@@ -3,7 +3,7 @@
 Document object for text files. [More...](#detailed-description)
 
 ```qml
-import Script 1.0
+import Script
 ```
 
 ## Properties

--- a/docs/API/script/textlocation.md
+++ b/docs/API/script/textlocation.md
@@ -3,7 +3,7 @@
 Defines a range of text in a file. [More...](#detailed-description)
 
 ```qml
-import Script 1.0
+import Script
 ```
 
 ## Properties

--- a/docs/API/script/textrange.md
+++ b/docs/API/script/textrange.md
@@ -3,7 +3,7 @@
 Defines a range of text in a text document [More...](#detailed-description)
 
 ```qml
-import Script 1.0
+import Script
 ```
 
 ## Properties

--- a/docs/API/script/toolbar.md
+++ b/docs/API/script/toolbar.md
@@ -3,7 +3,7 @@
 Description of a RC file toolbar. [More...](#detailed-description)
 
 ```qml
-import Script 1.0
+import Script
 ```
 
 ## Properties

--- a/docs/API/script/toolbaritem.md
+++ b/docs/API/script/toolbaritem.md
@@ -3,7 +3,7 @@
 Description of a RC file toolbar item. [More...](#detailed-description)
 
 ```qml
-import Script 1.0
+import Script
 ```
 
 ## Properties

--- a/docs/API/script/userdialog.md
+++ b/docs/API/script/userdialog.md
@@ -3,7 +3,7 @@
 Singleton with methods to display common dialog to the user. [More...](#detailed-description)
 
 ```qml
-import Script 1.0
+import Script
 ```
 
 ## Methods

--- a/docs/API/script/utils.md
+++ b/docs/API/script/utils.md
@@ -3,7 +3,7 @@
 Singleton with utility methods. [More...](#detailed-description)
 
 ```qml
-import Script 1.0
+import Script
 ```
 
 ## Methods

--- a/docs/API/script/widget.md
+++ b/docs/API/script/widget.md
@@ -3,7 +3,7 @@
 Description of a RC file widget. [More...](#detailed-description)
 
 ```qml
-import Script 1.0
+import Script
 ```
 
 ## Properties

--- a/docs/contributing/unit-tests.md
+++ b/docs/contributing/unit-tests.md
@@ -58,8 +58,8 @@ Each line will run a file from the `test_data` directory, for example the first 
 A QML test is using the module `Script.Test` and the item `TestCase`. Each function will be called automatically and returns true or false, depending of the test results.
 
 ```qml
-import Script 1.0
-import Script.Test 1.0
+import Script
+import Script.Test
 
 TestCase {
     name: "FileInfo"

--- a/docs/getting-started/script.md
+++ b/docs/getting-started/script.md
@@ -28,7 +28,7 @@ QML scripts are written using the `Script` item.
 
 ```qml
 // Script description
-import Script 1.0
+import Script
 
 Script {
     function init() {
@@ -51,7 +51,7 @@ For example, here is a small ui file named `my-script.ui`
 The script using this ui file will be called `my-script.qml`:
 ```qml
 // Script description
-import Script 1.0
+import Script
 
 ScriptDialog {
     function init() {
@@ -84,7 +84,7 @@ Here is the list of supported widgets for your dialogs, and how to access them f
 |`QDoubleSpinBox`|Value (double) via `data.objectName`|
 |`QComboBox`|Text via `data.objectName`, the list of values is available via `data.objectNameModel`|
 
-A note about `QComboBox`: if the combobox is editable, it will use the list of values as input data for completion.
+A note about `QComboBox`: if the combo box is editable, it will use the list of values as input data for completion.
 
 ### Alternative: using QtQuick
 
@@ -92,10 +92,10 @@ You can also use directly QtQuick and QtQcuick.Controls if you want, for example
 
 ```qml
 // Script description
-import QtQuick 2.12
-import QtQuick.Controls 2.12
-import QtQuick.Layouts 1.11
-import Script 1.0
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import Script
 
 ApplicationWindow {
     width: 300

--- a/examples/ex_gui_interactive.qml
+++ b/examples/ex_gui_interactive.qml
@@ -1,6 +1,6 @@
 // Example of an interactive GUI script
 
-import Script 1.0
+import Script
 
 ScriptDialog {
     id: root

--- a/examples/ex_gui_interactive.qml
+++ b/examples/ex_gui_interactive.qml
@@ -1,4 +1,13 @@
 // Example of an interactive GUI script
+/*
+  This file is part of Knut.
+
+  SPDX-FileCopyrightText: 2024 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+
+  SPDX-License-Identifier: BSD-3-Clause
+
+  Contact KDAB at <info@kdab.com> for commercial licensing options.
+*/
 
 import Script
 

--- a/examples/ex_gui_progressbar.qml
+++ b/examples/ex_gui_progressbar.qml
@@ -1,6 +1,6 @@
 // Example of an interactive GUI script
 
-import Script 1.0
+import Script
 
 ScriptDialog {
     id: root

--- a/examples/ex_gui_progressbar.qml
+++ b/examples/ex_gui_progressbar.qml
@@ -1,4 +1,13 @@
 // Example of an interactive GUI script
+/*
+  This file is part of Knut.
+
+  SPDX-FileCopyrightText: 2024 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+
+  SPDX-License-Identifier: BSD-3-Clause
+
+  Contact KDAB at <info@kdab.com> for commercial licensing options.
+*/
 
 import Script
 

--- a/examples/ex_script_dialog.qml
+++ b/examples/ex_script_dialog.qml
@@ -1,6 +1,15 @@
 // Example script with all the different widgets managed by ScriptDialog showing how to set/get data
+/*
+  This file is part of Knut.
 
-import Script 1.0
+  SPDX-FileCopyrightText: 2024 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+
+  SPDX-License-Identifier: BSD-3-Clause
+
+  Contact KDAB at <info@kdab.com> for commercial licensing options.
+*/
+
+import Script
 
 ScriptDialog {
     id: root

--- a/src/core/qml/Script/Test/TestCase.qml
+++ b/src/core/qml/Script/Test/TestCase.qml
@@ -1,6 +1,6 @@
-import QtQuick 2.12
-import Script 1.0
-import Script.Test 1.0
+import QtQuick
+import Script
+import Script.Test
 
 /*!
  * \qmltype TestCase

--- a/src/core/scriptdialogitem.cpp
+++ b/src/core/scriptdialogitem.cpp
@@ -50,7 +50,7 @@ namespace Core {
  * button `objectName` as parameter. `QDialogButtonBox` `accepted` or `rejected` signals are automatically connected.
  *
  * ```qml
- * import Script 1.0
+ * import Script
  *
  * ScriptDialog {
  *     property string text1: data.lineEdit

--- a/src/core/scriptitem.cpp
+++ b/src/core/scriptitem.cpp
@@ -22,7 +22,7 @@ namespace Core {
  * can't have any children in QML. It can be used as the basis for non visual QML scripts:
  *
  * ```qml
- * import Script 1.0
+ * import Script
  *
  * Script {
  * // ...

--- a/src/core/scriptrunner.cpp
+++ b/src/core/scriptrunner.cpp
@@ -235,8 +235,8 @@ QVariant ScriptRunner::runJavascript(const QString &fileName, QQmlEngine *engine
 {
     const QString text =
         QStringLiteral(
-            "import QtQml 2.12\n"
-            "import Script 1.0\n"
+            "import QtQml\n"
+            "import Script\n"
             "import \"%1\" as MyScript\n"
             "QtObject { property var _scriptResult; Component.onCompleted : _scriptResult = MyScript.main() }")
             .arg(QUrl::fromLocalFile(fileName).toString());

--- a/src/gui/scriptpanel.cpp
+++ b/src/gui/scriptpanel.cpp
@@ -42,7 +42,7 @@ function main() {
 
 constexpr char DefaultScriptDialog[] = R"(// Description of the script
 
-import Script 1.0
+import Script
 
 ScriptDialog {
     id: root

--- a/test_data/tst_dir.qml
+++ b/test_data/tst_dir.qml
@@ -8,9 +8,9 @@
   Contact KDAB at <info@kdab.com> for commercial licensing options.
 */
 
-import QtQuick 2.12
-import Script 1.0
-import Script.Test 1.0
+import QtQuick
+import Script
+import Script.Test
 
 TestCase {
     name: "Dir"

--- a/test_data/tst_fileinfo.qml
+++ b/test_data/tst_fileinfo.qml
@@ -8,9 +8,9 @@
   Contact KDAB at <info@kdab.com> for commercial licensing options.
 */
 
-import QtQuick 2.12
-import Script 1.0
-import Script.Test 1.0
+import QtQuick
+import Script
+import Script.Test
 
 TestCase {
     name: "FileInfo"

--- a/test_data/tst_project.qml
+++ b/test_data/tst_project.qml
@@ -8,9 +8,9 @@
   Contact KDAB at <info@kdab.com> for commercial licensing options.
 */
 
-import QtQuick 2.12
-import Script 1.0
-import Script.Test 1.0
+import QtQuick
+import Script
+import Script.Test
 
 TestCase {
     name: "Project"

--- a/test_data/tst_rcdocument.qml
+++ b/test_data/tst_rcdocument.qml
@@ -8,9 +8,9 @@
   Contact KDAB at <info@kdab.com> for commercial licensing options.
 */
 
-import QtQuick 2.12
-import Script 1.0
-import Script.Test 1.0
+import QtQuick
+import Script
+import Script.Test
 
 TestCase {
     name: "RcDocument"

--- a/test_data/tst_settings.qml
+++ b/test_data/tst_settings.qml
@@ -8,9 +8,9 @@
   Contact KDAB at <info@kdab.com> for commercial licensing options.
 */
 
-import QtQuick 2.12
-import Script 1.0
-import Script.Test 1.0
+import QtQuick
+import Script
+import Script.Test
 
 TestCase {
     name: "Settings"

--- a/test_data/tst_utils.qml
+++ b/test_data/tst_utils.qml
@@ -8,9 +8,9 @@
   Contact KDAB at <info@kdab.com> for commercial licensing options.
 */
 
-import QtQuick 2.2
-import Script 1.0
-import Script.Test 1.0
+import QtQuick
+import Script
+import Script.Test
 
 TestCase {
     name: "Utils"

--- a/tools/cpp2doc/docwriter.cpp
+++ b/tools/cpp2doc/docwriter.cpp
@@ -123,7 +123,7 @@ static constexpr char TypeFile[] = R"(# %1
 %2 [More...](#detailed-description)
 
 ```qml
-import %3 1.0
+import %3
 ```
 )";
 


### PR DESCRIPTION
It's the new way with Qt6, we don't need to set version in import.

Remove them from everywhere, as it makes things easier.

Also, as I was at it, add missing license to examples.