### PR TITLE
fix: modification of the setTranslation function for the case where the node is untranslated

### DIFF
--- a/src/core/qttsdocument.cpp
+++ b/src/core/qttsdocument.cpp
@@ -297,10 +297,11 @@ QString QtTsMessage::translation() const
     return QString::fromUtf8(m_message.child("translation").text().as_string());
 }
 
-void QtTsMessage::setTranslation(const QString &translate)
+void QtTsMessage::setTranslation(const QString &translation)
 {
-    LOG("QtTsMessage::setTranslation", translate);
-    m_message.child("translation").set_value(translate.toUtf8().constData());
+    LOG("QtTsMessage::setTranslation", translation);
+    m_message.child("translation").remove_attribute("type");
+    m_message.child("translation").text().set(translation.toUtf8().constData());
     qobject_cast<QtTsDocument *>(parent())->setHasChanged(true);
     Q_EMIT translationChanged();
 }

--- a/test_data/tst_qttsdocument/language_translation.ts
+++ b/test_data/tst_qttsdocument/language_translation.ts
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<TS version="2.1" language="FR_fr">
+    <context>
+        <name>foo</name>
+        <message>
+            <location filename="bla.cpp"/>
+            <source>text_translate</source>
+            <translation/>
+        </message>
+        <message>
+            <location filename="blo.cpp"/>
+            <source>text_translate</source>
+            <translation type="unfinished" />
+        </message>
+        <message>
+            <location filename="foo.cpp"/>
+            <source>text_translate_new</source>
+            <translation>text_french_new</translation>
+        </message>
+    </context>
+</TS>

--- a/tests/tst_qttsdocument.cpp
+++ b/tests/tst_qttsdocument.cpp
@@ -126,6 +126,17 @@ private slots:
         }
     }
 
+    void changeTranslation()
+    {
+        Core::QtTsDocument document;
+        document.load(Test::testDataPath() + QStringLiteral("/tst_qttsdocument/language_translation.ts"));
+        const auto messages = document.messages();
+        for (const auto &message : messages) {
+            message->setTranslation("new translation");
+            QCOMPARE(message->translation(), "new translation");
+        }
+    }
+
     void createFromEmptyFile()
     {
         Core::QtTsDocument document;


### PR DESCRIPTION
previous commit on PR #82 