### PR TITLE
chore(ci): Remove pre_commit job from GH Actions

### DIFF
--- a/.github/workflows/knut-tests.yml
+++ b/.github/workflows/knut-tests.yml
@@ -17,13 +17,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 jobs:
-  pre_commit:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v3
-      - uses: pre-commit/action@v3.0.1
-
   build:
     runs-on: ${{ matrix.os }}
     name: ${{ matrix.name }}


### PR DESCRIPTION
This is now done by pre-commit.ci, which is faster and should even be
able to auto-fix certain things.
