### PR TITLE
feat: Select Smaller/Larger/Next/Previous Syntax Nodes

### DIFF
--- a/docs/API/knut/codedocument.md
+++ b/docs/API/knut/codedocument.md
@@ -20,6 +20,7 @@ Inherited properties: [TextDocument properties](../knut/textdocument.md#properti
 |array&lt;[QueryMatch](../knut/querymatch.md)> |**[query](#query)**(string query)|
 |[QueryMatch](../knut/querymatch.md) |**[queryFirst](#queryFirst)**(string query)|
 |array&lt;[QueryMatch](../knut/querymatch.md)> |**[queryInRange](#queryInRange)**([RangeMark](../knut/rangemark.md) range, string query)|
+|int |**[selectLargerSyntaxNode](#selectLargerSyntaxNode)**(int count = 1)|
 ||**[selectSymbol](#selectSymbol)**(string name, int options = TextDocument.NoFindFlags)|
 |[Symbol](../knut/symbol.md) |**[symbolUnderCursor](#symbolUnderCursor)**()|
 |array&lt;[Symbol](../knut/symbol.md)> |**[symbols](#symbols)**()|
@@ -79,6 +80,12 @@ Also see: [Tree-sitter in Knut](../../getting-started/treesitter.md)
 
 Searches for the given `query`, but only in the provided `range`.
 
+
+#### <a name="selectLargerSyntaxNode"></a>int **selectLargerSyntaxNode**(int count = 1)
+
+Selects the text of the next larger syntax node that the selection is in.
+
+It does so `count` times and returns the resulting cursor position.
 
 #### <a name="selectSymbol"></a>**selectSymbol**(string name, int options = TextDocument.NoFindFlags)
 

--- a/docs/API/knut/codedocument.md
+++ b/docs/API/knut/codedocument.md
@@ -21,6 +21,9 @@ Inherited properties: [TextDocument properties](../knut/textdocument.md#properti
 |[QueryMatch](../knut/querymatch.md) |**[queryFirst](#queryFirst)**(string query)|
 |array&lt;[QueryMatch](../knut/querymatch.md)> |**[queryInRange](#queryInRange)**([RangeMark](../knut/rangemark.md) range, string query)|
 |int |**[selectLargerSyntaxNode](#selectLargerSyntaxNode)**(int count = 1)|
+|int |**[selectNextSyntaxNode](#selectNextSyntaxNode)**(int count = 1)|
+|int |**[selectPreviousSyntaxNode](#selectPreviousSyntaxNode)**(int count = 1)|
+|int |**[selectSmallerSyntaxNode](#selectSmallerSyntaxNode)**(int count = 1)|
 ||**[selectSymbol](#selectSymbol)**(string name, int options = TextDocument.NoFindFlags)|
 |[Symbol](../knut/symbol.md) |**[symbolUnderCursor](#symbolUnderCursor)**()|
 |array&lt;[Symbol](../knut/symbol.md)> |**[symbols](#symbols)**()|
@@ -86,6 +89,36 @@ Searches for the given `query`, but only in the provided `range`.
 Selects the text of the next larger syntax node that the selection is in.
 
 It does so `count` times and returns the resulting cursor position.
+
+#### <a name="selectNextSyntaxNode"></a>int **selectNextSyntaxNode**(int count = 1)
+
+Selects the next syntax node following the current selection.
+
+If there is no next syntax node in the current level, it increases the selection to the next larger syntax node and
+searches from there. See also: `CodeDocument::selectLargerSyntaxNode`
+
+It does so `count` times and returns the resulting cursor position.
+
+Note that this only selects "named" Tree-sitter nodes, so punctuation and other unnamed nodes are skipped.
+
+#### <a name="selectPreviousSyntaxNode"></a>int **selectPreviousSyntaxNode**(int count = 1)
+
+Selects the previous syntax node before the current selection.
+
+If there is no previous syntax node in the current level, it increases the selection to the next larger syntax node
+and searches from there. See also: `CodeDocument::selectLargerSyntaxNode`
+
+It does so `count` times and returns the resulting cursor position.
+
+Note that this only selects "named" Tree-sitter nodes, so punctuation and other unnamed nodes are skipped.
+
+#### <a name="selectSmallerSyntaxNode"></a>int **selectSmallerSyntaxNode**(int count = 1)
+
+Selects the left-most next smaller syntax node within the current selection.
+
+It does so `count` times and returns the resulting cursor position.
+
+Note that this only selects "named" Tree-sitter nodes, so punctuation and other unnamed nodes are skipped.
 
 #### <a name="selectSymbol"></a>**selectSymbol**(string name, int options = TextDocument.NoFindFlags)
 

--- a/src/core/codedocument.cpp
+++ b/src/core/codedocument.cpp
@@ -438,7 +438,7 @@ int CodeDocument::selectLargerSyntaxNode(int count /* = 1*/)
 
     selectRegion(currentNode.startPosition(), currentNode.endPosition());
 
-    return position();
+    LOG_RETURN("pos", position());
 }
 
 /*!
@@ -476,9 +476,12 @@ int CodeDocument::selectSmallerSyntaxNode(int count /* = 1*/)
 
     if (node.has_value()) {
         selectRegion(node->startPosition(), node->endPosition());
+    } else {
+        spdlog::warn(
+            "CodeDocument::selectSmallerSyntaxNode: No smaller node found! Do you currently not have a selection?");
     }
 
-    return position();
+    LOG_RETURN("pos", position());
 }
 
 static std::optional<treesitter::Node>
@@ -528,7 +531,7 @@ int CodeDocument::selectNextSyntaxNode(int count /*= 1*/)
         selectRegion(target->startPosition(), target->endPosition());
     }
 
-    return position();
+    LOG_RETURN("pos", position());
 }
 
 /*!
@@ -555,7 +558,7 @@ int CodeDocument::selectPreviousSyntaxNode(int count /*= 1*/)
         selectRegion(target->startPosition(), target->endPosition());
     }
 
-    return position();
+    LOG_RETURN("pos", position());
 }
 
 /*!

--- a/src/core/codedocument.cpp
+++ b/src/core/codedocument.cpp
@@ -413,7 +413,7 @@ void CodeDocument::selectSymbol(const QString &name, int options)
  */
 int CodeDocument::selectLargerSyntaxNode(int count /* = 1*/)
 {
-    LOG("CodeDocument::selectLargerSyntaxNode", LOG_ARG("count", count));
+    LOG_AND_MERGE("CodeDocument::selectLargerSyntaxNode", LOG_ARG("count", count));
 
     auto currentNode = m_treeSitterHelper->nodeCoveringRange(selectionStart(), selectionEnd());
 
@@ -452,7 +452,7 @@ int CodeDocument::selectLargerSyntaxNode(int count /* = 1*/)
  */
 int CodeDocument::selectSmallerSyntaxNode(int count /* = 1*/)
 {
-    LOG("CodeDocument::selectSmallerSyntaxNode", LOG_ARG("count", count));
+    LOG_AND_MERGE("CodeDocument::selectSmallerSyntaxNode", LOG_ARG("count", count));
 
     auto smallerNodes =
         kdalgorithms::filtered(m_treeSitterHelper->nodesInRange(createRangeMark()), [](const auto &node) {
@@ -518,7 +518,7 @@ findSibling(const treesitter::Node &start, treesitter::Node (treesitter::Node::*
  */
 int CodeDocument::selectNextSyntaxNode(int count /*= 1*/)
 {
-    LOG("CodeDocument::selectNextSyntaxNode", LOG_ARG("count", count));
+    LOG_AND_MERGE("CodeDocument::selectNextSyntaxNode", LOG_ARG("count", count));
 
     auto node = m_treeSitterHelper->nodeCoveringRange(selectionStart(), selectionEnd());
 
@@ -545,7 +545,7 @@ int CodeDocument::selectNextSyntaxNode(int count /*= 1*/)
  */
 int CodeDocument::selectPreviousSyntaxNode(int count /*= 1*/)
 {
-    LOG("CodeDocument::selectPreviousSyntaxNode", LOG_ARG("count", count));
+    LOG_AND_MERGE("CodeDocument::selectPreviousSyntaxNode", LOG_ARG("count", count));
 
     auto node = m_treeSitterHelper->nodeCoveringRange(selectionStart(), selectionEnd());
 

--- a/src/core/codedocument.cpp
+++ b/src/core/codedocument.cpp
@@ -441,6 +441,15 @@ int CodeDocument::selectLargerSyntaxNode(int count /* = 1*/)
     return position();
 }
 
+/*!
+ * \qmlmethod int CodeDocument::selectSmallerSyntaxNode(int count = 1)
+ *
+ * Selects the left-most next smaller syntax node within the current selection.
+ *
+ * It does so `count` times and returns the resulting cursor position.
+ *
+ * Note that this only selects "named" Tree-sitter nodes, so punctuation and other unnamed nodes are skipped.
+ */
 int CodeDocument::selectSmallerSyntaxNode(int count /* = 1*/)
 {
     LOG("CodeDocument::selectSmallerSyntaxNode", LOG_ARG("count", count));
@@ -467,6 +476,83 @@ int CodeDocument::selectSmallerSyntaxNode(int count /* = 1*/)
 
     if (node.has_value()) {
         selectRegion(node->startPosition(), node->endPosition());
+    }
+
+    return position();
+}
+
+static std::optional<treesitter::Node>
+findSibling(const treesitter::Node &start, treesitter::Node (treesitter::Node::*nextFunction)() const, int count)
+{
+    auto node = start;
+
+    std::optional<treesitter::Node> target = node;
+    for (/*count already initialized*/; count > 0; --count) {
+        auto next = std::invoke(nextFunction, node);
+        while (next.isNull() && !node.parent().isNull()) {
+            node = node.parent();
+            next = std::invoke(nextFunction, node);
+        }
+        if (next.isNull()) {
+            // We're already at the very end/top, nowhere else to go
+            break;
+        }
+        node = next;
+        target = next;
+    }
+
+    return target;
+}
+
+/*!
+ * \qmlmethod int CodeDocument::selectNextSyntaxNode(int count = 1)
+ *
+ * Selects the next syntax node following the current selection.
+ *
+ * If there is no next syntax node in the current level, it increases the selection to the next larger syntax node and
+ * searches from there. See also: `CodeDocument::selectLargerSyntaxNode`
+ *
+ * It does so `count` times and returns the resulting cursor position.
+ *
+ * Note that this only selects "named" Tree-sitter nodes, so punctuation and other unnamed nodes are skipped.
+ */
+int CodeDocument::selectNextSyntaxNode(int count /*= 1*/)
+{
+    LOG("CodeDocument::selectNextSyntaxNode", LOG_ARG("count", count));
+
+    auto node = m_treeSitterHelper->nodeCoveringRange(selectionStart(), selectionEnd());
+
+    auto target = findSibling(node, &treesitter::Node::nextNamedSibling, count);
+
+    if (target.has_value()) {
+        selectRegion(target->startPosition(), target->endPosition());
+    }
+
+    return position();
+}
+
+/*!
+ * \qmlmethod int CodeDocument::selectPreviousSyntaxNode(int count = 1)
+ *
+ * Selects the previous syntax node before the current selection.
+ *
+ * If there is no previous syntax node in the current level, it increases the selection to the next larger syntax node
+ * and searches from there. See also: `CodeDocument::selectLargerSyntaxNode`
+ *
+ * It does so `count` times and returns the resulting cursor position.
+ *
+ * Note that this only selects "named" Tree-sitter nodes, so punctuation and other unnamed nodes are skipped.
+ */
+int CodeDocument::selectPreviousSyntaxNode(int count /*= 1*/)
+{
+    LOG("CodeDocument::selectPreviousSyntaxNode", LOG_ARG("count", count));
+
+    auto node = m_treeSitterHelper->nodeCoveringRange(selectionStart(), selectionEnd());
+
+    auto target = findSibling(node, &treesitter::Node::previousNamedSibling, count);
+
+    if (target.has_value()) {
+        selectRegion(target->startPosition(), target->endPosition());
     }
 
     return position();

--- a/src/core/codedocument.h
+++ b/src/core/codedocument.h
@@ -82,6 +82,9 @@ public:
 public slots:
     void selectSymbol(const QString &name, int options = NoFindFlags);
 
+    int selectLargerSyntaxNode(int count = 1);
+    int selectSmallerSyntaxNode(int count = 1);
+
 protected:
     explicit CodeDocument(Type type, QObject *parent = nullptr);
 

--- a/src/core/codedocument.h
+++ b/src/core/codedocument.h
@@ -84,6 +84,8 @@ public slots:
 
     int selectLargerSyntaxNode(int count = 1);
     int selectSmallerSyntaxNode(int count = 1);
+    int selectNextSyntaxNode(int count = 1);
+    int selectPreviousSyntaxNode(int count = 1);
 
 protected:
     explicit CodeDocument(Type type, QObject *parent = nullptr);

--- a/src/core/codedocument_p.h
+++ b/src/core/codedocument_p.h
@@ -35,6 +35,7 @@ public:
 
     std::shared_ptr<treesitter::Query> constructQuery(const QString &query);
     QList<treesitter::Node> nodesInRange(const RangeMark &range);
+    treesitter::Node nodeCoveringRange(int start, int end);
 
     const QList<Core::Symbol *> &symbols();
 

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -92,6 +92,8 @@ FORWARD_TO_DOCUMENT(TextDocument, redo)
 
 FORWARD_TO_DOCUMENT(CodeDocument, selectLargerSyntaxNode)
 FORWARD_TO_DOCUMENT(CodeDocument, selectSmallerSyntaxNode)
+FORWARD_TO_DOCUMENT(CodeDocument, selectNextSyntaxNode)
+FORWARD_TO_DOCUMENT(CodeDocument, selectPreviousSyntaxNode)
 FORWARD_TO_DOCUMENT(CodeDocument, followSymbol)
 FORWARD_TO_DOCUMENT(CodeDocument, switchDeclarationDefinition)
 
@@ -213,6 +215,8 @@ MainWindow::MainWindow(QWidget *parent)
     connect(ui->actionSelectBlockUp, &QAction::triggered, this, &MainWindow::selectBlockUp);
     connect(ui->actionSelectLargerSyntaxNode, &QAction::triggered, this, &MainWindow::selectLargerSyntaxNode);
     connect(ui->actionSelectSmallerSyntaxNode, &QAction::triggered, this, &MainWindow::selectSmallerSyntaxNode);
+    connect(ui->actionSelectNextSyntaxNode, &QAction::triggered, this, &MainWindow::selectNextSyntaxNode);
+    connect(ui->actionSelectPreviousSyntaxNode, &QAction::triggered, this, &MainWindow::selectPreviousSyntaxNode);
     connect(ui->actionTreeSitterInspector, &QAction::triggered, this, &MainWindow::inspectTreeSitter);
     connect(ui->actionDeleteMethod, &QAction::triggered, this, &MainWindow::deleteMethod);
 
@@ -600,6 +604,9 @@ void MainWindow::updateActions()
 
     const bool isCodeDocument = codeDocument != nullptr;
     ui->actionSelectLargerSyntaxNode->setEnabled(isCodeDocument);
+    ui->actionSelectSmallerSyntaxNode->setEnabled(isCodeDocument);
+    ui->actionSelectNextSyntaxNode->setEnabled(isCodeDocument);
+    ui->actionSelectPreviousSyntaxNode->setEnabled(isCodeDocument);
     ui->actionTreeSitterInspector->setEnabled(isCodeDocument);
 
     const bool rcEnabled = qobject_cast<Core::RcDocument *>(document);

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -175,6 +175,8 @@ MainWindow::MainWindow(QWidget *parent)
     connect(ui->actionSelectToBlockEnd, &QAction::triggered, this, &MainWindow::selectBlockEnd);
     connect(ui->actionSelectToBlockStart, &QAction::triggered, this, &MainWindow::selectBlockStart);
     connect(ui->actionSelectBlockUp, &QAction::triggered, this, &MainWindow::selectBlockUp);
+    connect(ui->actionSelectLargerSyntaxNode, &QAction::triggered, this, &MainWindow::selectLargerSyntaxNode);
+    connect(ui->actionSelectSmallerSyntaxNode, &QAction::triggered, this, &MainWindow::selectSmallerSyntaxNode);
     connect(ui->actionTreeSitterInspector, &QAction::triggered, this, &MainWindow::inspectTreeSitter);
     connect(ui->actionDeleteMethod, &QAction::triggered, this, &MainWindow::deleteMethod);
 
@@ -309,6 +311,18 @@ void MainWindow::selectBlockUp()
 {
     if (auto cppDocument = qobject_cast<Core::CppDocument *>(Core::Project::instance()->currentDocument()))
         cppDocument->selectBlockUp();
+}
+
+void MainWindow::selectLargerSyntaxNode()
+{
+    if (auto cppDocument = qobject_cast<Core::CodeDocument *>(Core::Project::instance()->currentDocument()))
+        cppDocument->selectLargerSyntaxNode();
+}
+
+void MainWindow::selectSmallerSyntaxNode()
+{
+    if (auto cppDocument = qobject_cast<Core::CodeDocument *>(Core::Project::instance()->currentDocument()))
+        cppDocument->selectSmallerSyntaxNode();
 }
 
 void MainWindow::commentSelection()
@@ -622,7 +636,6 @@ void MainWindow::updateActions()
     const bool lspEnabled = codeDocument && codeDocument->hasLspClient();
     ui->actionFollowSymbol->setEnabled(lspEnabled);
     ui->actionSwitchDeclDef->setEnabled(lspEnabled);
-    ui->actionTreeSitterInspector->setEnabled(codeDocument != nullptr);
 
     const bool cppEnabled = codeDocument && qobject_cast<Core::CppDocument *>(document);
     ui->actionSwitchHeaderSource->setEnabled(cppEnabled);
@@ -634,6 +647,10 @@ void MainWindow::updateActions()
     ui->actionSelectToBlockStart->setEnabled(cppEnabled);
     ui->actionSelectBlockUp->setEnabled(cppEnabled);
     ui->actionDeleteMethod->setEnabled(cppEnabled);
+
+    const bool isCodeDocument = codeDocument != nullptr;
+    ui->actionSelectLargerSyntaxNode->setEnabled(isCodeDocument);
+    ui->actionTreeSitterInspector->setEnabled(isCodeDocument);
 
     const bool rcEnabled = qobject_cast<Core::RcDocument *>(document);
     ui->actionCreateQrc->setEnabled(rcEnabled);

--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -69,7 +69,7 @@ private:
     // C++
     void followSymbol();
     void switchDeclarationDefinition();
-    void switchHeaderSource();
+    void openHeaderSource();
     void gotoBlockStart();
     void gotoBlockEnd();
     void selectBlockStart();

--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -75,6 +75,8 @@ private:
     void selectBlockStart();
     void selectBlockEnd();
     void selectBlockUp();
+    void selectLargerSyntaxNode();
+    void selectSmallerSyntaxNode();
     void commentSelection();
     void toggleSection();
     void inspectTreeSitter();

--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -67,20 +67,24 @@ private:
     void redo();
 
     // C++
-    void followSymbol();
-    void switchDeclarationDefinition();
     void openHeaderSource();
     void gotoBlockStart();
     void gotoBlockEnd();
     void selectBlockStart();
     void selectBlockEnd();
     void selectBlockUp();
-    void selectLargerSyntaxNode();
-    void selectSmallerSyntaxNode();
     void commentSelection();
     void toggleSection();
     void inspectTreeSitter();
     void deleteMethod();
+
+    // Code
+    void followSymbol();
+    void switchDeclarationDefinition();
+    void selectLargerSyntaxNode();
+    void selectSmallerSyntaxNode();
+    void selectNextSyntaxNode();
+    void selectPreviousSyntaxNode();
 
     // Rc
     void createQrc();

--- a/src/gui/mainwindow.ui
+++ b/src/gui/mainwindow.ui
@@ -100,6 +100,8 @@
     <addaction name="actionSelectBlockUp"/>
     <addaction name="actionSelectLargerSyntaxNode"/>
     <addaction name="actionSelectSmallerSyntaxNode"/>
+    <addaction name="actionSelectNextSyntaxNode"/>
+    <addaction name="actionSelectPreviousSyntaxNode"/>
     <addaction name="separator"/>
     <addaction name="actionDeleteMethod"/>
     <addaction name="separator"/>
@@ -501,6 +503,22 @@
    </property>
    <property name="shortcut">
     <string>Ctrl+D</string>
+   </property>
+  </action>
+  <action name="actionSelectNextSyntaxNode">
+   <property name="text">
+    <string>Select Next Syntax Node</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+N</string>
+   </property>
+  </action>
+  <action name="actionSelectPreviousSyntaxNode">
+   <property name="text">
+    <string>Select Previous Syntax Node</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+Shift+N</string>
    </property>
   </action>
  </widget>

--- a/src/gui/mainwindow.ui
+++ b/src/gui/mainwindow.ui
@@ -54,7 +54,7 @@
      <x>0</x>
      <y>0</y>
      <width>1463</width>
-     <height>24</height>
+     <height>23</height>
     </rect>
    </property>
    <widget class="QMenu" name="menu_File">
@@ -81,9 +81,9 @@
     <addaction name="actionCreateQrc"/>
     <addaction name="actionCreateUi"/>
    </widget>
-   <widget class="QMenu" name="menuC">
+   <widget class="QMenu" name="menuCode">
     <property name="title">
-     <string>&amp;C++</string>
+     <string>&amp;Code</string>
     </property>
     <addaction name="actionSwitchHeaderSource"/>
     <addaction name="actionFollowSymbol"/>
@@ -98,6 +98,9 @@
     <addaction name="actionSelectToBlockEnd"/>
     <addaction name="separator"/>
     <addaction name="actionSelectBlockUp"/>
+    <addaction name="actionSelectLargerSyntaxNode"/>
+    <addaction name="actionSelectSmallerSyntaxNode"/>
+    <addaction name="separator"/>
     <addaction name="actionDeleteMethod"/>
     <addaction name="separator"/>
     <addaction name="actionTreeSitterInspector"/>
@@ -151,7 +154,7 @@
    <addaction name="menu_Script"/>
    <addaction name="menuEdit"/>
    <addaction name="menu_View"/>
-   <addaction name="menuC"/>
+   <addaction name="menuCode"/>
    <addaction name="menu_Rc"/>
    <addaction name="menu_Help"/>
   </widget>
@@ -233,6 +236,9 @@
   </action>
   <action name="actionSwitchHeaderSource">
    <property name="text">
+    <string>Switch Header/Source</string>
+   </property>
+   <property name="toolTip">
     <string>Switch Header/Source</string>
    </property>
    <property name="shortcut">
@@ -456,6 +462,17 @@
     <string>Select Block Up</string>
    </property>
    <property name="shortcut">
+    <string>Ctrl+Shift+U</string>
+   </property>
+  </action>
+  <action name="actionSelectLargerSyntaxNode">
+   <property name="text">
+    <string>Select Larger Syntax Node</string>
+   </property>
+   <property name="toolTip">
+    <string>Enlarges the current selection to the parent node in the Tree-Sitter concrete syntax tree</string>
+   </property>
+   <property name="shortcut">
     <string>Ctrl+U</string>
    </property>
   </action>
@@ -476,6 +493,14 @@
    </property>
    <property name="shortcut">
     <string>Ctrl+Shift+R</string>
+   </property>
+  </action>
+  <action name="actionSelectSmallerSyntaxNode">
+   <property name="text">
+    <string>Select Smaller Syntax Node</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+D</string>
    </property>
   </action>
  </widget>

--- a/src/treesitter/CMakeLists.txt
+++ b/src/treesitter/CMakeLists.txt
@@ -10,8 +10,14 @@
 
 project(knut-treesitter LANGUAGES CXX)
 
-set(PROJECT_SOURCES node.cpp parser.cpp predicates.cpp query.cpp
-                    transformation.cpp tree.cpp)
+set(PROJECT_SOURCES
+    node.cpp
+    parser.cpp
+    predicates.cpp
+    query.cpp
+    transformation.cpp
+    tree.cpp
+    tree_cursor.cpp)
 
 add_library(${PROJECT_NAME} STATIC ${PROJECT_SOURCES})
 target_link_libraries(

--- a/src/treesitter/node.cpp
+++ b/src/treesitter/node.cpp
@@ -142,6 +142,26 @@ QList<Node> Node::namedChildren() const
     return result;
 }
 
+Node Node::nextSibling() const
+{
+    return Node(ts_node_next_sibling(m_node));
+}
+
+Node Node::previousSibling() const
+{
+    return Node(ts_node_prev_sibling(m_node));
+}
+
+Node Node::nextNamedSibling() const
+{
+    return Node(ts_node_next_named_sibling(m_node));
+}
+
+Node Node::previousNamedSibling() const
+{
+    return Node(ts_node_prev_named_sibling(m_node));
+}
+
 uint32_t Node::startPosition() const
 {
     return ts_node_start_byte(m_node) / sizeof(QChar);

--- a/src/treesitter/node.h
+++ b/src/treesitter/node.h
@@ -71,6 +71,7 @@ public:
     TSNode m_node;
 
     friend class Tree;
+    friend class TreeCursor;
     friend class QueryCursor;
     friend class QueryMatch;
 };

--- a/src/treesitter/node.h
+++ b/src/treesitter/node.h
@@ -40,6 +40,11 @@ public:
     uint32_t childCount() const;
     QVector<Node> children() const;
 
+    Node nextSibling() const;
+    Node previousSibling() const;
+    Node nextNamedSibling() const;
+    Node previousNamedSibling() const;
+
     uint32_t startPosition() const;
     uint32_t endPosition() const;
 

--- a/src/treesitter/tree_cursor.cpp
+++ b/src/treesitter/tree_cursor.cpp
@@ -1,0 +1,39 @@
+#include "tree_cursor.h"
+
+#include <tree_sitter/api.h>
+
+#include <QString>
+
+namespace treesitter {
+TreeCursor::TreeCursor(Node node)
+{
+    m_cursor = ts_tree_cursor_new(node.m_node);
+}
+
+Node TreeCursor::currentNode() const
+{
+    return ts_tree_cursor_current_node(&m_cursor);
+}
+QString TreeCursor::currentFieldName() const
+{
+    auto fieldName = ts_tree_cursor_current_field_name(&m_cursor);
+
+    return fieldName ? QString(fieldName) : QString();
+}
+
+bool TreeCursor::gotoFirstChild()
+{
+    return ts_tree_cursor_goto_first_child(&m_cursor);
+}
+
+bool TreeCursor::gotoNextSibling()
+{
+    return ts_tree_cursor_goto_next_sibling(&m_cursor);
+}
+
+bool TreeCursor::gotoParent()
+{
+    return ts_tree_cursor_goto_parent(&m_cursor);
+}
+
+}

--- a/src/treesitter/tree_cursor.h
+++ b/src/treesitter/tree_cursor.h
@@ -1,0 +1,35 @@
+/*
+  This file is part of Knut.
+
+  SPDX-FileCopyrightText: 2024 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+
+  SPDX-License-Identifier: GPL-3.0-only
+
+  Contact KDAB at <info@kdab.com> for commercial licensing options.
+*/
+
+#pragma once
+
+#include "node.h"
+
+namespace treesitter {
+
+class TreeCursor
+{
+public:
+    TreeCursor(Node);
+    TreeCursor(const TreeCursor &) = delete;
+    TreeCursor(TreeCursor &&) = delete;
+
+    Node currentNode() const;
+    /// This returns a null QString if there is no field name
+    QString currentFieldName() const;
+
+    bool gotoFirstChild();
+    bool gotoNextSibling();
+    bool gotoParent();
+
+private:
+    TSTreeCursor m_cursor;
+};
+}

--- a/tests/tst_codedocument.cpp
+++ b/tests/tst_codedocument.cpp
@@ -22,6 +22,11 @@
 #include <QTest>
 #include <kdalgorithms.h>
 
+#define INIT_KNUT_PROJECT                                                                                              \
+    Core::KnutCore core;                                                                                               \
+    auto project = Core::Project::instance();                                                                          \
+    project->setRoot(Test::testDataPath() + "/projects/cpp-project")
+
 class TestCodeDocument : public QObject
 {
     Q_OBJECT
@@ -54,9 +59,7 @@ private slots:
     {
         CHECK_CLANGD_VERSION;
 
-        Core::KnutCore core;
-        auto project = Core::Project::instance();
-        project->setRoot(Test::testDataPath() + "/projects/cpp-project");
+        INIT_KNUT_PROJECT;
 
         auto cppDocument = qobject_cast<Core::CodeDocument *>(project->open("myobject.cpp"));
         const auto cppSymbols = cppDocument->symbols();
@@ -137,9 +140,7 @@ private slots:
         QFETCH(Core::Symbol::Kind, symbolKind);
         QFETCH(Lsp::Position, position);
 
-        Core::KnutCore core;
-        auto project = Core::Project::instance();
-        project->setRoot(Test::testDataPath() + "/projects/cpp-project");
+        INIT_KNUT_PROJECT;
 
         const auto document = qobject_cast<Core::CodeDocument *>(project->open(fileName));
 
@@ -160,9 +161,7 @@ private slots:
 
     void symbolUnderCursorCache()
     {
-        Core::KnutCore core;
-        auto project = Core::Project::instance();
-        project->setRoot(Test::testDataPath() + "/projects/cpp-project");
+        INIT_KNUT_PROJECT;
 
         const auto document = qobject_cast<Core::CodeDocument *>(project->open("main.cpp"));
 
@@ -182,9 +181,7 @@ private slots:
     {
         CHECK_CLANGD_VERSION;
 
-        Core::KnutCore core;
-        auto project = Core::Project::instance();
-        project->setRoot(Test::testDataPath() + "/projects/cpp-project");
+        INIT_KNUT_PROJECT;
 
         auto headerDocument = qobject_cast<Core::CodeDocument *>(project->open("myobject.h"));
 
@@ -214,9 +211,7 @@ private slots:
     {
         CHECK_CLANGD_VERSION;
 
-        Core::KnutCore core;
-        auto project = Core::Project::instance();
-        project->setRoot(Test::testDataPath() + "/projects/cpp-project");
+        INIT_KNUT_PROJECT;
 
         auto codedocument = qobject_cast<Core::CodeDocument *>(project->open("main.cpp"));
 
@@ -271,9 +266,7 @@ private slots:
     {
         CHECK_CLANGD_VERSION;
 
-        Core::KnutCore core;
-        auto project = Core::Project::instance();
-        project->setRoot(Test::testDataPath() + "/projects/cpp-project");
+        INIT_KNUT_PROJECT;
 
         auto mainfile = qobject_cast<Core::CodeDocument *>(project->open("main.cpp"));
         auto cppfile = qobject_cast<Core::CodeDocument *>(project->open("myobject.cpp"));
@@ -337,9 +330,7 @@ private slots:
     {
         CHECK_CLANGD;
 
-        Core::KnutCore core;
-        auto project = Core::Project::instance();
-        project->setRoot(Test::testDataPath() + "/projects/cpp-project");
+        INIT_KNUT_PROJECT;
 
         auto codedocument = qobject_cast<Core::CodeDocument *>(Core::Project::instance()->get("myobject.h"));
 
@@ -358,9 +349,7 @@ private slots:
 
     void query()
     {
-        Core::KnutCore core;
-        auto project = Core::Project::instance();
-        project->setRoot(Test::testDataPath() + "/projects/cpp-project");
+        INIT_KNUT_PROJECT;
 
         auto codedocument = qobject_cast<Core::CodeDocument *>(Core::Project::instance()->get("main.cpp"));
 
@@ -391,9 +380,7 @@ private slots:
 
     void failedQuery()
     {
-        Core::KnutCore core;
-        auto project = Core::Project::instance();
-        project->setRoot(Test::testDataPath() + "/projects/cpp-project");
+        INIT_KNUT_PROJECT;
 
         auto codedocument = qobject_cast<Core::CodeDocument *>(Core::Project::instance()->get("main.cpp"));
 
@@ -416,9 +403,7 @@ private slots:
 
     void queryInRange()
     {
-        Core::KnutCore core;
-        auto project = Core::Project::instance();
-        project->setRoot(Test::testDataPath() + "/projects/cpp-project");
+        INIT_KNUT_PROJECT;
 
         auto codedocument = qobject_cast<Core::CodeDocument *>(Core::Project::instance()->get("main.cpp"));
 


### PR DESCRIPTION
This allows navigating the code semantically.

Fix #64
