### PR TITLE
fix: save settings file in different directory in testing mode

### DIFF
--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -231,6 +231,9 @@ bool Settings::setValue(QString path, const QVariant &value)
 
 QString Settings::userFilePath() const
 {
+    if (isTesting()) {
+        return QDir::tempPath() + '/' + SettingsName;
+    }
     return QDir::homePath() + '/' + SettingsName;
 }
 
@@ -268,10 +271,6 @@ void Settings::loadKnutSettings()
 
 void Settings::saveSettings()
 {
-    // Don't save settings if testing
-    if (isTesting())
-        return;
-
     const auto &settings = isUser() ? m_userSettings : m_projectSettings;
     const auto &filePath = isUser() ? userFilePath() : projectFilePath();
 

--- a/tests/tst_settings.cpp
+++ b/tests/tst_settings.cpp
@@ -18,12 +18,11 @@
 ///////////////////////////////////////////////////////////////////////////////
 // Tests Data
 ///////////////////////////////////////////////////////////////////////////////
-// Use a test fixture for Settings, to be able to save (even if it's used in a test)
 class SettingsFixture : public Core::Settings
 {
 public:
     SettingsFixture()
-        : Settings(Core::Settings::Mode::Cli) // Not Testing
+        : Settings(Core::Settings::Mode::Test)
     {
     }
 };


### PR DESCRIPTION
before this commit, we didn't save json files in test mode, so as not to overwrite the json file already present in the user's home directory. now we save this json file in the temp directory.

We have also improved tst_settings.cpp, which now saves the json file in the temp directory.