### PR TITLE
feat: Skip macros in C++ during parsing

### DIFF
--- a/docs/API/knut/cppdocument.md
+++ b/docs/API/knut/cppdocument.md
@@ -298,6 +298,7 @@ The returned QueryMatch instances contain the following captures:
 - `declaration`: The full declaration of the method
 - `function`: The function declaration, without the return type
 - `name`: The name of the function
+- `return-type`: The return type of the function without any reference/pointer specifiers (i.e. `&`/`*`)
 
 #### <a name="queryMethodDefinition"></a>array&lt;[QueryMatch](../knut/querymatch.md)> **queryMethodDefinition**(string scope, string methodName)
 

--- a/src/core/codedocument.cpp
+++ b/src/core/codedocument.cpp
@@ -848,4 +848,10 @@ AstNode CodeDocument::astNodeAt(int pos)
     return {};
 }
 
+QList<treesitter::Range> CodeDocument::includedRanges() const
+{
+    // An empty list tells the parser to include the entire document.
+    return {};
+}
+
 } // namespace Core

--- a/src/core/codedocument.h
+++ b/src/core/codedocument.h
@@ -15,6 +15,7 @@
 #include "querymatch.h"
 #include "symbol.h"
 #include "textdocument.h"
+#include "treesitter/parser.h"
 #include "treesitter/query.h"
 
 #include <functional>
@@ -78,6 +79,8 @@ public:
     QString hover(int position, std::function<void(const QString &)> asyncCallback = {}) const;
 
     Q_INVOKABLE Core::AstNode astNodeAt(int pos);
+
+    virtual QList<treesitter::Range> includedRanges() const;
 
 public slots:
     void selectSymbol(const QString &name, int options = NoFindFlags);

--- a/src/core/codedocument_p.cpp
+++ b/src/core/codedocument_p.cpp
@@ -48,7 +48,12 @@ treesitter::Parser &TreeSitterHelper::parser()
 std::optional<treesitter::Tree> &TreeSitterHelper::syntaxTree()
 {
     if (!m_tree) {
-        m_tree = parser().parseString(m_document->text());
+        auto &parser = this->parser();
+        if (!parser.setIncludedRanges(m_document->includedRanges())) {
+            spdlog::warn("TreeSitterHelper::syntaxTree: Unable to set the included ranges on the treesitter parser!");
+            parser.setIncludedRanges({});
+        }
+        m_tree = parser.parseString(m_document->text());
         if (!m_tree) {
             spdlog::warn("CodeDocument::syntaxTree: Failed to parse document {}!", m_document->fileName());
         }

--- a/src/core/core/settings.json
+++ b/src/core/core/settings.json
@@ -30,6 +30,13 @@
             "LANG_NEUTRAL": "[default]"
         }
     },
+    "cpp": {
+        "excluded_macros": [
+            "AFX_EXT_CLASS",
+            "[A-Z_]*EXPORT[A-Z_]*",
+            "Q_OBJECT"
+        ]
+    },
     "mime_types": {
         "c": "cpp_type",
         "cpp": "cpp_type",

--- a/src/core/cppdocument.cpp
+++ b/src/core/cppdocument.cpp
@@ -692,6 +692,7 @@ MessageMap CppDocument::mfcExtractMessageMap(const QString &className /* = ""*/)
  * - `declaration`: The full declaration of the method
  * - `function`: The function declaration, without the return type
  * - `name`: The name of the function
+ * - `return-type`: The return type of the function without any reference/pointer specifiers (i.e. `&`/`*`)
  */
 Core::QueryMatchList CppDocument::queryMethodDeclaration(const QString &className, const QString &functionName)
 {
@@ -1543,6 +1544,67 @@ QStringList CppDocument::keywords() const
 QStringList CppDocument::primitiveTypes() const
 {
     return Utils::cppPrimitiveTypes();
+}
+
+QList<treesitter::Range> CppDocument::includedRanges() const
+{
+    QList<QString> macros {"AFX_EXT_CLASS"};
+    QList<treesitter::Range> ranges;
+    treesitter::Point lastPoint {0, 0};
+    uint32_t lastByte = 0;
+
+    auto document = textEdit()->document();
+
+    QRegularExpression regex(macros.join("|"));
+    for (auto block = document->firstBlock(); block.isValid(); block = block.next()) {
+        QRegularExpressionMatch match;
+        auto searchFrom = 0;
+        auto index = block.text().indexOf(regex, searchFrom, &match);
+
+        // Run this in a loop to support multiple macros on the same line.
+        while (index != -1) {
+            // We need to construct a range from the end of the last match to the start of the current match.
+            //
+            // Note that the ranges have an inclusive start and an exclusive end..
+            //
+            // Also Note that the column seems to be in bytes, not characters.
+            // This is why we multiply by sizeof(QChar) to get the correct column.
+            // At least that's what the TreeSitterInspector shows us.
+            auto endPoint = treesitter::Point {.row = static_cast<uint32_t>(block.blockNumber()),
+                                               .column = static_cast<uint32_t>(index * sizeof(QChar))};
+            ranges.push_back({.start_point = lastPoint,
+                              .end_point = endPoint,
+                              .start_byte = lastByte,
+                              // No need to add - 1 here, the ranges are exclusive at the end.
+                              .end_byte = static_cast<uint32_t>((block.position() + index) * sizeof(QChar))});
+
+            auto matchLength = match.capturedLength();
+            lastByte = static_cast<uint32_t>((block.position() + index + matchLength) * sizeof(QChar));
+            lastPoint = {.row = static_cast<uint32_t>(block.blockNumber()),
+                         .column = static_cast<uint32_t>((index + matchLength) * sizeof(QChar))};
+            if (lastPoint.column == static_cast<uint32_t>(block.length())) {
+                ++lastPoint.row;
+                lastPoint.column = 0;
+            }
+
+            searchFrom = index + matchLength;
+            index = block.text().indexOf(regex, searchFrom, &match);
+        }
+    }
+
+    if (!ranges.isEmpty()) {
+        // Add the last range, up to the end of the document, but only if we have another range.
+        // Leaving the ranges empty will parse the entire document, so that's easiest.
+        auto endPoint =
+            treesitter::Point {.row = static_cast<uint32_t>(document->blockCount() - 1),
+                               .column = static_cast<uint32_t>(document->lastBlock().length() * sizeof(QChar))};
+        ranges.push_back({.start_point = lastPoint,
+                          .end_point = endPoint,
+                          .start_byte = lastByte,
+                          .end_byte = static_cast<uint32_t>(document->characterCount() * sizeof(QChar))});
+    }
+
+    return ranges;
 }
 
 } // namespace Core

--- a/src/core/cppdocument.h
+++ b/src/core/cppdocument.h
@@ -60,6 +60,8 @@ public:
     bool changeBaseClass(CppDocument *header, CppDocument *source, const QString &className,
                          const QString &newClassBaseName);
 
+    QList<treesitter::Range> includedRanges() const override;
+
 public slots:
     Core::CppDocument *openHeaderSource();
 

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -49,6 +49,7 @@ public:
     static inline constexpr char RcAssetFlags[] = "/rc/asset_flags";
     static inline constexpr char RcAssetColors[] = "/rc/asset_transparent_colors";
     static inline constexpr char RcLanguageMap[] = "/rc/language_map";
+    static inline constexpr char CppExcludedMacros[] = "/cpp/excluded_macros";
     static inline constexpr char SaveLogsToFile[] = "/logs/saveToFile";
     static inline constexpr char ScriptPaths[] = "/script_paths";
     static inline constexpr char Tab[] = "/text_editor/tab";

--- a/src/gui/optionsdialog.h
+++ b/src/gui/optionsdialog.h
@@ -35,6 +35,7 @@ private:
     void initializeScriptPathSettings();
     void initializeScriptBehaviorSettings();
     void initializeRcSettings();
+    void initializeCppSettings();
 
     void openUserSettings();
     void openProjectSettings();

--- a/src/gui/optionsdialog.ui
+++ b/src/gui/optionsdialog.ui
@@ -626,6 +626,49 @@
        </item>
       </layout>
      </widget>
+     <widget class="QWidget" name="stackedWidgetPage5">
+      <layout class="QVBoxLayout" name="verticalLayout_4">
+       <item>
+        <widget class="QGroupBox" name="groupBox_7">
+         <property name="title">
+          <string>C++ Files</string>
+         </property>
+         <layout class="QGridLayout" name="gridLayout_11">
+          <item row="0" column="0">
+           <widget class="QLabel" name="cppLabelExcludedMacros">
+            <property name="toolTip">
+             <string>The Macros listed here will be excluded from parsing (supports Regex).</string>
+            </property>
+            <property name="text">
+             <string>Excluded Macros</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="2">
+           <widget class="QPushButton" name="cppAddExcludedMacro">
+            <property name="text">
+             <string>Add</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="2">
+           <widget class="QPushButton" name="cppRemoveExcludedMacro">
+            <property name="text">
+             <string>Remove</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1" rowspan="3">
+           <widget class="QListView" name="cppExcludedMacros"/>
+          </item>
+         </layout>
+        </widget>
+       </item>
+      </layout>
+     </widget>
     </widget>
    </item>
    <item row="0" column="1">
@@ -682,6 +725,11 @@
      <item>
       <property name="text">
        <string>Rc Files</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>C++ Files</string>
       </property>
      </item>
     </widget>

--- a/src/gui/treesitterinspector.cpp
+++ b/src/gui/treesitterinspector.cpp
@@ -182,6 +182,7 @@ void TreeSitterInspector::changeText()
         Core::LoggerDisabler disableLogging;
         text = m_document->text();
     }
+    m_parser.setIncludedRanges(m_document->includedRanges());
     auto tree = m_parser.parseString(text);
     if (tree.has_value()) {
         m_treemodel.setTree(std::move(tree.value()), makePredicates(), ui->enableUnnamed->isChecked());

--- a/src/gui/treesittertreemodel.cpp
+++ b/src/gui/treesittertreemodel.cpp
@@ -74,11 +74,13 @@ QVariant TreeSitterTreeModel::TreeNode::data(int column) const
             return QString("%1: %2").arg(fieldName, m_node.type());
         }
     case 1:
-        return QString("[%1:%2] - [%3:%4]")
+        return QString("[%1:%2](%3) - [%4:%5](%6)")
             .arg(m_node.startPoint().row)
             .arg(m_node.startPoint().column)
+            .arg(m_node.startPosition())
             .arg(m_node.endPoint().row)
-            .arg(m_node.endPoint().column);
+            .arg(m_node.endPoint().column)
+            .arg(m_node.endPosition());
     default:
         break;
     }

--- a/src/treesitter/parser.cpp
+++ b/src/treesitter/parser.cpp
@@ -58,6 +58,11 @@ std::optional<Tree> Parser::parseString(const QString &text, const Tree *old_tre
     return tree ? Tree(tree) : std::optional<Tree> {};
 }
 
+bool Parser::setIncludedRanges(const QList<Range> &ranges)
+{
+    return ts_parser_set_included_ranges(m_parser, ranges.data(), ranges.size());
+}
+
 const TSLanguage *Parser::language() const
 {
     return ts_parser_language(m_parser);

--- a/src/treesitter/parser.h
+++ b/src/treesitter/parser.h
@@ -12,6 +12,8 @@
 
 #include "core/document.h"
 #include <QString>
+#include <tree_sitter/api.h>
+#include <vector>
 
 struct TSParser;
 struct TSLanguage;
@@ -19,6 +21,7 @@ struct TSLanguage;
 namespace treesitter {
 
 class Tree;
+using Range = TSRange;
 
 class Parser
 {
@@ -36,6 +39,21 @@ public:
     void swap(Parser &other) noexcept;
 
     std::optional<Tree> parseString(const QString &text, const Tree *old_tree = nullptr) const;
+
+    /**
+     * Parse only the given ranges.
+     * Note: if the ranges are empty, the entire document is parsed.
+     *
+     * From tree_sitter/api.h:
+     * [The] given ranges must be ordered from earliest to latest in the document,
+     * and they must not overlap. That is, the following must hold for all
+     * `i` < `length - 1`: ranges[i].end_byte <= ranges[i + 1].start_byte
+     *
+     * If this requirement is not satisfied, the operation will fail, the ranges
+     * will not be assigned, and this function will return `false`. On success,
+     * this function returns `true`
+     */
+    bool setIncludedRanges(const QList<Range> &ranges);
 
     const TSLanguage *language() const;
 

--- a/test_data/tst_cppdocument/treesitterExcludesMacros/AFX_EXT_CLASS.h
+++ b/test_data/tst_cppdocument/treesitterExcludesMacros/AFX_EXT_CLASS.h
@@ -1,0 +1,10 @@
+#pragma once
+
+class AFX_EXT_CLASS TestClass : public AFX_EXT_CLASSBase{
+publicAFX_EXT_CLASS:
+  void testMethod();
+
+private:
+  int AFX_EXT_CLASS m_count;
+};
+AFX_EXT_CLASS

--- a/tests/tst_cppdocument_treesitter.cpp
+++ b/tests/tst_cppdocument_treesitter.cpp
@@ -358,6 +358,29 @@ private slots:
             QVERIFY(headerFile.compare());
         }
     }
+
+    void excludeMacros()
+    {
+        Test::testCppDocument("tst_cppdocument/treesitterExcludesMacros", "AFX_EXT_CLASS.h", [](auto *document) {
+            auto match = document->queryClassDefinition("TestClass");
+            QVERIFY(!match.isEmpty());
+            QCOMPARE(match.get("name").text(), "TestClass");
+            QCOMPARE(match.get("base").text(), "Base");
+
+            match = document->queryMember("TestClass", "m_count");
+            QVERIFY(!match.isEmpty());
+            QCOMPARE(match.get("name").text(), "m_count");
+            QCOMPARE(match.get("type").text(), "int");
+            QCOMPARE(match.get("member").text(), "int AFX_EXT_CLASS m_count;");
+
+            auto matches = document->queryMethodDeclaration("TestClass", "testMethod");
+            QCOMPARE(matches.length(), 1);
+            match = matches.front();
+            QVERIFY(!match.isEmpty());
+            QCOMPARE(match.get("name").text(), "testMethod");
+            QCOMPARE(match.get("return-type").text(), "void");
+        });
+    }
 };
 
 QTEST_MAIN(TestCppDocumentTreeSitter)


### PR DESCRIPTION
We can use TreeSitters "included ranges" to specify which parts of the document to include when parsing.

In our case we actually use this to exclude certain ranges, which are C++ pre-processor macros that would otherwise screw up our parsing.

Fix #30
