### PR TITLE
fix: save settings on exit

### DIFF
--- a/src/core/knutcore.cpp
+++ b/src/core/knutcore.cpp
@@ -86,6 +86,10 @@ void KnutCore::process(const QStringList &arguments)
     else
         mode = Settings::Mode::Gui;
 
+    // Finish scripts using scriptFinished(), not just when the last window is closed
+    if (mode == Settings::Mode::Test)
+        QApplication::setQuitOnLastWindowClosed(false);
+
     initialize(mode);
 
     const QStringList positionalArguments = parser.positionalArguments();

--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -85,6 +85,7 @@ Settings::Settings(Mode mode, QObject *parent)
 
 Settings::~Settings()
 {
+    saveOnExit();
     m_instance = nullptr;
 }
 
@@ -296,6 +297,13 @@ void Settings::saveSettings()
     QTextStream stream(&file);
     stream << QString::fromStdString(settings.dump(4, ' ', false));
     emit settingsSaved();
+}
+
+void Settings::saveOnExit()
+{
+    if (m_saveTimer->isActive()) {
+        saveSettings();
+    }
 }
 
 bool Settings::isUser() const

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -136,6 +136,7 @@ private:
     void updatePaths(const QString &path, const std::string &json_path, bool add);
     void saveSettings();
     bool isUser() const;
+    void saveOnExit();
 
     inline static Settings *m_instance = nullptr;
 


### PR DESCRIPTION
We add a way to save settings before exiting if there are changes. This make the tests to pass with the corrected knut.json