### PR TITLE
Check type information provided by symbols

### DIFF
--- a/docs/API/knut/typedsymbol.md
+++ b/docs/API/knut/typedsymbol.md
@@ -1,0 +1,31 @@
+# TypedSymbol
+
+Represents a symbol with a type [More...](#detailed-description)
+
+```qml
+import Knut
+```
+
+## Properties
+
+| | Name |
+|-|-|
+|string|**[type](#type)**|
+
+## Detailed Description
+
+This symbol has a type associated with it, like a variable or a member of a class.
+
+## Property Documentation
+
+#### <a name="type"></a>string **type**
+
+The type of this symbol.
+
+The type is the part of the symbol that describes what kind of value it holds. For example, the type of a variable.
+This symbol will extract the type as-written in the original source, but with whitespace
+[simplified](https://doc.qt.io/qt-6/qstring.html#simplified). So if e.g. the source code is `const string  &`, it
+will be extracted as `const string &`. The type will **not** be resolved to a fully qualified path (like
+`std::string` for the previous example).
+
+This property is read-only.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -54,6 +54,7 @@ nav:
                 - QueryCapture: API/knut/querycapture.md
                 - QueryMatch: API/knut/querymatch.md
                 - Symbol: API/knut/symbol.md
+                - TypedSymbol: API/knut/typedsymbol.md
             - CppDocument:
                 - CppDocument: API/knut/cppdocument.md
                 - DataExchange: API/knut/dataexchange.md

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -94,6 +94,8 @@ set(PROJECT_SOURCES
     textdocument_p.h
     texteditor.h
     texteditor.cpp
+    typedsymbol.h
+    typedsymbol.cpp
     qtuidocument.h
     qtuidocument.cpp
     qttsdocument.h

--- a/src/core/cppdocument.cpp
+++ b/src/core/cppdocument.cpp
@@ -120,12 +120,13 @@ auto queryMemberSymbols(CodeDocument *const document) -> QList<Core::Symbol *>
     auto fieldIdentifier = "(field_identifier) @name @selectionRange";
     auto members = document->query(QString(R"EOF(
                                         (field_declaration
-                                          type: (_) @type
+                                          (type_qualifier)? @type @typeAndName
+                                          type: (_) @type @typeAndName
                                           declarator: [
                                             %1
                                             (_ %1) @decl_type
                                             (_ (_ %1) @decl_type) @decl_type
-                                          ]
+                                          ] @typeAndName
                                           ; We need to filter out functions, they are already captured
                                           ; by the functionSymbols query
                                           (#not_is? @decl_type function_declarator)) @range)EOF")

--- a/src/core/functionsymbol.cpp
+++ b/src/core/functionsymbol.cpp
@@ -74,7 +74,7 @@ QString FunctionSymbol::signature() const
 
 QString FunctionSymbol::returnTypeFromQueryMatch() const
 {
-    return m_queryMatch.getAllJoined("return").text();
+    return m_queryMatch.getAllJoined("return").text().simplified();
 }
 
 QString FunctionSymbol::returnType() const

--- a/src/core/symbol.cpp
+++ b/src/core/symbol.cpp
@@ -14,6 +14,7 @@
 #include "functionsymbol.h"
 #include "logger.h"
 #include "project.h"
+#include "typedsymbol.h"
 #include "utils/log.h"
 
 #include <kdalgorithms.h>
@@ -100,6 +101,9 @@ Symbol *Symbol::makeSymbol(QObject *parent, const QueryMatch &match, Kind kind)
     }
     if (kind == Class || kind == Struct) {
         return new ClassSymbol(parent, match, kind);
+    }
+    if (kind == Field || kind == Variable) {
+        return new TypedSymbol(parent, match, kind);
     }
     return new Symbol(parent, match, kind);
 }

--- a/src/core/typedsymbol.cpp
+++ b/src/core/typedsymbol.cpp
@@ -1,0 +1,48 @@
+#include "typedsymbol.h"
+
+#include <kdalgorithms.h>
+
+namespace Core {
+
+/*!
+ * \qmltype TypedSymbol
+ * \brief Represents a symbol with a type
+ * \inqmlmodule Knut
+ * \ingroup CodeDocument
+ *
+ * This symbol has a type associated with it, like a variable or a member of a class.
+ */
+
+/*!
+ * \qmlproperty string TypedSymbol::type
+ * The type of this symbol.
+ *
+ * The type is the part of the symbol that describes what kind of value it holds. For example, the type of a variable.
+ * This symbol will extract the type as-written in the original source, but with whitespace
+ * [simplified](https://doc.qt.io/qt-6/qstring.html#simplified). So if e.g. the source code is `const string  &`, it
+ * will be extracted as `const string &`. The type will **not** be resolved to a fully qualified path (like
+ * `std::string` for the previous example).
+ *
+ * This property is read-only.
+ */
+
+TypedSymbol::TypedSymbol(QObject *parent, const QueryMatch &match, Kind kind)
+    : Symbol(parent, match, kind)
+{
+    // C++ has a strange way of parsing, where pointer and reference specifiers are parsed as a parent
+    // of the identifier, and not part of the type. The easiest way to remedy this is to get the whole
+    // range spanning the type and name and then erase the name.
+    auto typeAndName = match.getAllJoined("typeAndName");
+    if (typeAndName.isValid()) {
+        m_type = typeAndName.textExcept(match.get("name")).simplified();
+    } else {
+        m_type = kdalgorithms::transformed(match.getAll("type"), &RangeMark::text).join(" ").simplified();
+    }
+}
+
+QString TypedSymbol::type() const
+{
+    return m_type;
+}
+
+}

--- a/src/core/typedsymbol.h
+++ b/src/core/typedsymbol.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "symbol.h"
+
+namespace Core {
+
+class TypedSymbol : public Symbol
+{
+    Q_OBJECT
+
+    Q_PROPERTY(QString type READ type CONSTANT)
+
+public:
+    QString type() const;
+
+private:
+    friend class Symbol;
+    TypedSymbol(QObject *parent, const QueryMatch &match, Kind kind);
+
+    QString m_type;
+};
+
+}

--- a/test_data/tst_symbol/return_type.h
+++ b/test_data/tst_symbol/return_type.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <string>
+
+using namespace std;
+
+void *freePtr();
+void *freePtrImpl() { return nullptr; }
+
+const std::string &freeReference();
+const std::string &freeReferenceImpl() {
+  return "";
+}
+
+const class T *const freeConstPtr();
+const class T *const freeConstPtrImpl() { return nullptr; }
+
+class MyClass {
+  MyClass() = default();
+  ~MyClass() = default();
+
+  void *memberPtr();
+  const string& memberReference();
+  const class T*    const memberConstPtr();
+};
+
+void*MyClass::memberPtrImpl() {
+  return nullptr;
+}
+
+const std::string& MyClass::memberReferenceImpl() {
+  return m_thing;
+}
+
+const
+class
+T
+*
+const
+MyClass::memberConstPtrImpl() {
+  return nullptr;
+}
+
+MyClassImpl::MyClassImpl()
+{
+}
+
+MyClassImpl::~MyClassImpl()
+{
+}

--- a/test_data/tst_symbol/typedsymbol.h
+++ b/test_data/tst_symbol/typedsymbol.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <string>
+
+class TestClass {
+private:
+  void   *m_ptr;
+  const std::string &m_lvalue_reference;
+  std::string&& m_rvalue_reference;
+  const class T*const m_const_ptr;
+};

--- a/tests/tst_symbol.cpp
+++ b/tests/tst_symbol.cpp
@@ -257,6 +257,54 @@ private slots:
         testTypedSymbol("TestClass::m_rvalue_reference", "std::string&&");
         testTypedSymbol("TestClass::m_const_ptr", "const class T*const");
     }
+
+    void functionSymbolReturnType_data()
+    {
+        QTest::addColumn<QString>("symbolName");
+        QTest::addColumn<QString>("returnType");
+
+        auto addRow = [&](const QString &symbolName, const QString &returnType) {
+            QTest::newRow(symbolName.toUtf8().constData()) << symbolName << returnType;
+        };
+
+        addRow("freePtr", "void *");
+        addRow("freePtrImpl", "void *");
+        addRow("freeReference", "const std::string &");
+        addRow("freeReferenceImpl", "const std::string &");
+        addRow("freeConstPtr", "const class T *const");
+        addRow("freeConstPtrImpl", "const class T *const");
+
+        addRow("MyClass::memberPtr", "void *");
+        addRow("MyClass::memberReference", "const string&");
+        addRow("MyClass::memberConstPtr", "const class T* const");
+
+        addRow("MyClass::memberPtrImpl", "void*");
+        addRow("MyClass::memberReferenceImpl", "const std::string&");
+        addRow("MyClass::memberConstPtrImpl", "const class T * const");
+
+        addRow("MyClass::MyClass", "");
+        addRow("MyClass::~MyClass", "");
+        addRow("MyClassImpl::MyClassImpl", "");
+        addRow("MyClassImpl::~MyClassImpl", "");
+    }
+
+    void functionSymbolReturnType()
+    {
+        QFETCH(QString, symbolName);
+        QFETCH(QString, returnType);
+
+        Core::KnutCore core;
+        Core::Project::instance()->setRoot(Test::testDataPath() + "/tst_symbol/");
+
+        auto codeDocument = qobject_cast<Core::CodeDocument *>(Core::Project::instance()->open("return_type.h"));
+        QVERIFY(codeDocument);
+
+        auto symbol = codeDocument->findSymbol(symbolName);
+        QVERIFY(symbol);
+        auto functionSymbol = qobject_cast<Core::FunctionSymbol *>(symbol);
+        QVERIFY(functionSymbol);
+        QCOMPARE(functionSymbol->returnType(), returnType);
+    }
 };
 
 QTEST_MAIN(TestSymbol)


### PR DESCRIPTION
Make sure that the type information returned by symbols is accurate by:

1. Adding a TypedSymbol that knows about the type of its symbol
2. Making sure FunctionSymbol can extract complex type signatures correctly

Fix #117 