### PR TITLE
feat: improve nextStep API in ScriptDialog

### DIFF
--- a/src/core/scriptdialogitem.cpp
+++ b/src/core/scriptdialogitem.cpp
@@ -231,7 +231,9 @@ void ScriptDialogItem::nextStep(const QString &title)
     //
     // This is likely just caused by a script that's indicating too few progress steps.
     // So just increase the maximum.
-    m_currentStepTitle = title;
+    if (!title.isEmpty()) {
+        m_currentStepTitle = title;
+    }
 
     if (m_stepCount != 0 && m_currentStep >= m_stepCount) {
         setStepCount(m_stepCount + 1);

--- a/src/core/scriptdialogitem.h
+++ b/src/core/scriptdialogitem.h
@@ -49,7 +49,7 @@ public:
     int stepCount() const;
 
     Q_INVOKABLE void firstStep(const QString &firstStep);
-    Q_INVOKABLE void nextStep(const QString &title);
+    Q_INVOKABLE void nextStep(const QString &title = QString());
     Q_INVOKABLE void runSteps(const QJSValue &generator);
 
     Q_INVOKABLE void compare(const QJSValue &actual, const QJSValue &expected, QString message = {});


### PR DESCRIPTION
 - if the string is empty (ie calling nextStep()), then repeat the previous string
 - Depends on : https://codereview.kdab.com/c/kdab/mfc-utils/+/144576