### PR TITLE
fix: Make Symbols & query... calls consistent

### DIFF
--- a/docs/API/knut/cppdocument.md
+++ b/docs/API/knut/cppdocument.md
@@ -250,7 +250,8 @@ The returned QueryMatch instance will have the following captures available:
 
 #### <a name="queryFunctionCall"></a>array&lt;[QueryMatch](../knut/querymatch.md)> **queryFunctionCall**(string functionName)
 
-Returns the list of function calls to the function `functionName`, no matter how many arguments they were called with.
+Returns the list of function calls to the function `functionName`, no matter how many arguments they were called
+with.
 
 The returned QueryMatch instances will have the following captures available:
 
@@ -283,7 +284,9 @@ Returns a QueryMatch object containing the member definition if it exists.
 The returned QueryMatch instance will have the following captures available:
 
 - `member`: The full definition of the member
-- `type`: The type of the member, without `const` or any reference/pointer specifiers (i.e. `&`/`*`)
+- `type`: The type of the member
+  - Because the C++ grammar associates pointers to the identifier and not the type this may capture multiple ranges.
+  - It is recommended to use `getAllJoined("type")` to get the full type.
 - `name`: The name of the member (should be equal to memberName)
 
 #### <a name="queryMethodDeclaration"></a>array&lt;[QueryMatch](../knut/querymatch.md)> **queryMethodDeclaration**(string className, string functionName)
@@ -298,7 +301,11 @@ The returned QueryMatch instances contain the following captures:
 - `declaration`: The full declaration of the method
 - `function`: The function declaration, without the return type
 - `name`: The name of the function
-- `return-type`: The return type of the function without any reference/pointer specifiers (i.e. `&`/`*`)
+- `parameter-list`: The full parameter list of the function
+- `parameters`: One capture per parameter, containing the type and name of the parameter, excluding comments!
+- `return`: The return type of the function
+  - Because the C++ grammar associates pointers to the identifier and not the type this may capture multiple ranges.
+  - It is recommended to use `getAllJoined("return")` to get the full type.
 
 #### <a name="queryMethodDefinition"></a>array&lt;[QueryMatch](../knut/querymatch.md)> **queryMethodDefinition**(string scope, string methodName)
 
@@ -313,6 +320,9 @@ Every QueryMatch returned by this function will have the following captures avai
 - `parameter-list` - The list of parameters
 - `parameters` - One capture per parameter, containing the type and name of the parameter, excluding comments!
 - `body` - The body of the method (including curly-braces)
+- `return` - The return type of the method
+  - Because the C++ grammar associates pointers to the identifier and not the type this may capture multiple ranges.
+  - It is recommended to use `getAllJoined("return")` to get the full type.
 
 Please note that the return type is not available, as TreeSitter is not able to parse it easily.
 

--- a/src/core/functionsymbol.cpp
+++ b/src/core/functionsymbol.cpp
@@ -96,7 +96,7 @@ const QList<FunctionArgument> &FunctionSymbol::arguments() const
 
 QList<FunctionArgument> FunctionSymbol::argumentsFromQueryMatch() const
 {
-    auto arguments = m_queryMatch.getAll("parameter");
+    auto arguments = m_queryMatch.getAll("parameters");
     auto to_function_arg = [this](const RangeMark &argument) {
         auto result = document()->queryInRange(argument, "(identifier) @name");
         auto nameRange = result.isEmpty() ? RangeMark() : result.first().get("name");

--- a/test_data/tst_symbol/return_type.h
+++ b/test_data/tst_symbol/return_type.h
@@ -16,8 +16,8 @@ const class T *const freeConstPtr();
 const class T *const freeConstPtrImpl() { return nullptr; }
 
 class MyClass {
-  MyClass() = default();
-  ~MyClass() = default();
+  MyClass();
+  ~MyClass() = default;
 
   void *memberPtr();
   const string& memberReference();

--- a/tests/tst_codedocument.cpp
+++ b/tests/tst_codedocument.cpp
@@ -356,7 +356,7 @@ private slots:
         Test::LogCounter counter;
         auto matches = codedocument->query(R"EOF(
                 (function_definition
-                  type: (_) @return-type
+                  type: (_) @return
                   declarator: (function_declarator
                     declarator: (identifier) @name (eq? @name "main")
                     parameters: (parameter_list
@@ -370,10 +370,10 @@ private slots:
         const auto &captures = match.captures();
         QCOMPARE(captures.size(), 4);
         QCOMPARE(match.getAll("name").size(), 1);
-        QCOMPARE(match.getAll("return-type").size(), 1);
+        QCOMPARE(match.getAll("return").size(), 1);
         QCOMPARE(match.getAll("param").size(), 2);
 
-        QCOMPARE(match.getAll("return-type").at(0).text(), "int");
+        QCOMPARE(match.getAll("return").at(0).text(), "int");
         QCOMPARE(match.getAll("param").at(0).text(), "int argc");
         QCOMPARE(match.getAll("param").at(1).text(), "char *argv[]");
     }

--- a/tests/tst_cppdocument.cpp
+++ b/tests/tst_cppdocument.cpp
@@ -240,13 +240,13 @@ private slots:
             QCOMPARE(methods.size(), 2);
 
             QCOMPARE(methods[0].get("name").text(), "sayMessage");
-            QCOMPARE(methods[0].get("return-type").text(), "void");
+            QCOMPARE(methods[0].get("return").text(), "void");
             QCOMPARE(methods[0].getAll("parameters").size(), 0);
             QCOMPARE(methods[0].get("parameter-list").text(), "()");
             QCOMPARE(methods[0].get("body").text(), "{\n    std::cout << m_message << std::endl;\n}");
 
             QCOMPARE(methods[1].get("name").text(), "sayMessage");
-            QCOMPARE(methods[1].get("return-type").text(), "void");
+            QCOMPARE(methods[1].get("return").text(), "void");
             QCOMPARE(methods[1].getAll("parameters").size(), 1);
             QCOMPARE(methods[1].get("parameter-list").text(), "(const std::string& test)");
             QVERIFY(methods[1].get("body").text().contains("m_enum = MyEnum::C"));


### PR DESCRIPTION
We have a lot of symbols that have corresponding functions to query them directly.
Before this commit they actually used completely different queries, which could result in inconsistency between the data returned from a symbol and from the query that should query the same thing.

This also fixes many pointer captures that weren't correct in many instances.

Fix #118