### PR TITLE
fix: simplify the API documentation

### DIFF
--- a/src/core/classsymbol.cpp
+++ b/src/core/classsymbol.cpp
@@ -17,7 +17,6 @@ namespace Core {
 /*!
  * \qmltype ClassSymbol
  * \brief Represents a class in the current file
- * \inqmlmodule Knut
  * \ingroup CodeDocument
  * \todo
  */

--- a/src/core/codedocument.cpp
+++ b/src/core/codedocument.cpp
@@ -38,7 +38,6 @@ namespace Core {
 /*!
  * \qmltype CodeDocument
  * \brief Base document object for any code that Knut can parse.
- * \inqmlmodule Knut
  * \ingroup CodeDocument/@first
  * \inherits TextDocument
  *

--- a/src/core/cppdocument.cpp
+++ b/src/core/cppdocument.cpp
@@ -182,7 +182,6 @@ namespace Core {
 /*!
  * \qmltype CppDocument
  * \brief Document object for a C++ file (source or header)
- * \inqmlmodule Knut
  * \ingroup CppDocument/@first
  * \inherits CodeDocument
  */

--- a/src/core/dataexchange.cpp
+++ b/src/core/dataexchange.cpp
@@ -18,7 +18,6 @@ namespace Core {
 /*!
  * \qmltype DataExchangeEntry
  * \brief Refers to a single entry within the `DoDataExchange`
- * \inqmlmodule Knut
  * \ingroup CppDocument
  * \sa DataExchange
  *
@@ -102,7 +101,6 @@ static QList<DataValidationEntry> queryDDVCalls(const QueryMatch &ddxFunction)
 /*!
  * \qmltype DataExchange
  * \brief DataExchange entries in a MFC C++ document.
- * \inqmlmodule Knut
  * \ingroup CppDocument
  *
  * The `DataExchange` object represents the data contained in the MFC `DoDataExchange` method.

--- a/src/core/dir.cpp
+++ b/src/core/dir.cpp
@@ -18,7 +18,6 @@ namespace Core {
 /*!
  * \qmltype Dir
  * \brief Singleton with methods to handle directories.
- * \inqmlmodule Knut
  * \ingroup Utilities
  *
  * The `Dir` singleton implements most of the static methods from `QDir`, check [QDir](https://doc.qt.io/qt-6/qdir.html)

--- a/src/core/document.cpp
+++ b/src/core/document.cpp
@@ -23,7 +23,6 @@ namespace Core {
 /*!
  * \qmltype Document
  * \brief Base class for all documents
- * \inqmlmodule Knut
  *
  * The `Document` class is the base class for all documents.
  * A document is a file loaded by Knut and that can be used in script (either to get data or to edit).

--- a/src/core/file.cpp
+++ b/src/core/file.cpp
@@ -19,7 +19,6 @@ namespace Core {
 /*!
  * \qmltype File
  * \brief Singleton with methods to handle files.
- * \inqmlmodule Knut
  * \ingroup Utilities
  *
  * The `File` singleton implements most of the static methods from `QFile`, check

--- a/src/core/fileinfo.cpp
+++ b/src/core/fileinfo.cpp
@@ -18,7 +18,6 @@ namespace Core {
 /*!
  * \qmltype FileInfo
  * \brief Singleton with methods to handle file information.
- * \inqmlmodule Knut
  * \ingroup Utilities
  *
  * The `FileInfo` singleton implements most of the static methods from `QFileInfo`, check

--- a/src/core/functionsymbol.cpp
+++ b/src/core/functionsymbol.cpp
@@ -19,7 +19,6 @@ namespace Core {
 /*!
  * \qmltype FunctionArgument
  * \brief Represents an argument to be passed to the function
- * \inqmlmodule Knut
  * \ingroup CodeDocument
  * \todo
  * \sa FunctionSymbol
@@ -37,7 +36,6 @@ namespace Core {
 /*!
  * \qmltype FunctionSymbol
  * \brief Represents a function or a method in the current file
- * \inqmlmodule Knut
  * \ingroup CodeDocument
  * \todo
  */

--- a/src/core/mark.cpp
+++ b/src/core/mark.cpp
@@ -22,7 +22,6 @@ namespace Core {
 /*!
  * \qmltype Mark
  * \brief Keeps track of a position in a text document.
- * \inqmlmodule Knut
  * \ingroup TextDocument
  * \sa TextDocument
  *

--- a/src/core/message.cpp
+++ b/src/core/message.cpp
@@ -18,7 +18,6 @@ namespace Core {
 /*!
  * \qmltype Message
  * \brief Singleton with methods to display different messages to the user.
- * \inqmlmodule Knut
  * \ingroup Utilities
  *
  * The `message` property in QML can be used to display different messages to the user, via logs.

--- a/src/core/messagemap.cpp
+++ b/src/core/messagemap.cpp
@@ -20,7 +20,6 @@ namespace Core {
 /*!
  * \qmltype MessageMapEntry
  * \brief Refers to a single entry within the `MessageMap`
- * \inqmlmodule Knut
  * \ingroup CppDocument
  * \sa MessageMap
  *
@@ -71,7 +70,6 @@ MessageMapEntry fromMessage(const QueryMatch &match, const RangeMark &range)
 /*!
  * \qmltype MessageMap
  * \brief Message map in a MFC C++ document
- * \inqmlmodule Knut
  * \ingroup CppDocument
  *
  * The `MessageMap` object represents the data contained in the MFC MessageMap.

--- a/src/core/project.cpp
+++ b/src/core/project.cpp
@@ -38,7 +38,6 @@ namespace Core {
 /*!
  * \qmltype Project
  * \brief Singleton for handling the current project.
- * \inqmlmodule Knut
  * The `Project` object is not meant to open multiple projects, but only open one.
  */
 

--- a/src/core/qdirvaluetype.cpp
+++ b/src/core/qdirvaluetype.cpp
@@ -15,7 +15,6 @@ namespace Core {
 /*!
  * \qmltype QDirValueType
  * \brief Wrapper around the `QDir` class.
- * \inqmlmodule Knut
  * \ingroup Utilities/@last
  * \sa Dir
  *

--- a/src/core/qfileinfovaluetype.cpp
+++ b/src/core/qfileinfovaluetype.cpp
@@ -15,7 +15,6 @@ namespace Core {
 /*!
  * \qmltype QFileInfoValueType
  * \brief Wrapper around the `QFileInfo` class.
- * \inqmlmodule Knut
  * \ingroup Utilities/@last
  * \sa FileInfo
  *

--- a/src/core/qttsdocument.cpp
+++ b/src/core/qttsdocument.cpp
@@ -22,7 +22,6 @@ namespace Core {
 /*!
  * \qmltype QtTsDocument
  * \brief Provides access to the content of a Ts file (Qt linguist).
- * \inqmlmodule Knut
  * \ingroup QtTsDocument/@first
  */
 
@@ -288,7 +287,6 @@ QList<QtTsMessage *> QtTsDocument::messages() const
 /*!
  * \qmltype QtTsMessage
  * \brief Provides access to message.
- * \inqmlmodule Knut
  * \ingroup QtTsDocument
  * \sa QtTsDocument
  */

--- a/src/core/qtuidocument.cpp
+++ b/src/core/qtuidocument.cpp
@@ -23,7 +23,6 @@ namespace Core {
 /*!
  * \qmltype QtUiDocument
  * \brief Provides access to the content of a Ui file (Qt designer file).
- * \inqmlmodule Knut
  * \ingroup QtUiDocument/@first
  */
 
@@ -171,7 +170,6 @@ Utils::QtUiWriter *QtUiDocument::uiWriter()
 /*!
  * \qmltype QtUiWidget
  * \brief Provides access to widget attributes in the ui files.
- * \inqmlmodule Knut
  * \ingroup QtUiDocument
  * \sa QtUiDocument
  */

--- a/src/core/querymatch.cpp
+++ b/src/core/querymatch.cpp
@@ -23,7 +23,6 @@ namespace Core {
 /*!
  * \qmltype QueryCapture
  * \brief Defines a capture made by a query.
- * \inqmlmodule Knut
  * \ingroup CodeDocument
  * \sa QueryMatch
  */
@@ -45,7 +44,6 @@ QString QueryCapture::toString() const
 /*!
  * \qmltype QueryMatch
  * \brief Contains all captures for a query match.
- * \inqmlmodule Knut
  * \ingroup CodeDocument
  * \sa CodeDocument::query
  *

--- a/src/core/rangemark.cpp
+++ b/src/core/rangemark.cpp
@@ -21,7 +21,6 @@ namespace Core {
 /*!
  * \qmltype RangeMark
  * \brief Keeps track of a range within a text document.
- * \inqmlmodule Knut
  * \ingroup TextDocument
  * \sa TextDocument
  *

--- a/src/core/rcdocument.cpp
+++ b/src/core/rcdocument.cpp
@@ -24,7 +24,6 @@ namespace Core {
 /*!
  * \qmltype RcDocument
  * \brief Provides access to the content of a RC file (MFC resource file).
- * \inqmlmodule Knut
  * \ingroup RcDocument/@first
  */
 

--- a/src/core/scriptdialogitem.cpp
+++ b/src/core/scriptdialogitem.cpp
@@ -39,7 +39,6 @@ namespace Core {
 /*!
  * \qmltype ScriptDialog
  * \brief QML Item for writing visual scripts.
- * \inqmlmodule Knut
  * \ingroup Items
  *
  * The `ScriptDialog` allows creating a script dialog based on a ui file. It requires creating a ui file with the same

--- a/src/core/scriptitem.cpp
+++ b/src/core/scriptitem.cpp
@@ -17,7 +17,6 @@ namespace Core {
 /*!
  * \qmltype Script
  * \brief Script object for writing non visual scripts.
- * \inqmlmodule Knut
  * \ingroup Items
  *
  * The `Script` is the base class for all creatable items in QML. It is needed as a `QtObject`

--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -50,7 +50,6 @@ static constexpr char SettingsName[] = "knut.json";
 /*!
  * \qmltype Settings
  * \brief Singleton for accessing and editing persistent settings.
- * \inqmlmodule Knut
  * \ingroup Utilities
  *
  * The settings are stored in a json file, and could be:

--- a/src/core/symbol.cpp
+++ b/src/core/symbol.cpp
@@ -24,7 +24,6 @@ namespace Core {
 /*!
  * \qmltype Symbol
  * \brief Represent a symbol in the current file
- * \inqmlmodule Knut
  * \ingroup CodeDocument
  */
 

--- a/src/core/textdocument.cpp
+++ b/src/core/textdocument.cpp
@@ -66,7 +66,6 @@ matchInBlock(const QTextBlock &block, const QRegularExpression &expr, int offset
 /*!
  * \qmltype TextDocument
  * \brief Document object for text files.
- * \inqmlmodule Knut
  * \ingroup TextDocument/@first
  * \inherits Document
  */

--- a/src/core/typedsymbol.cpp
+++ b/src/core/typedsymbol.cpp
@@ -7,7 +7,6 @@ namespace Core {
 /*!
  * \qmltype TypedSymbol
  * \brief Represents a symbol with a type
- * \inqmlmodule Knut
  * \ingroup CodeDocument
  *
  * This symbol has a type associated with it, like a variable or a member of a class.

--- a/src/core/userdialog.cpp
+++ b/src/core/userdialog.cpp
@@ -22,7 +22,6 @@ namespace Core {
 /*!
  * \qmltype UserDialog
  * \brief Singleton with methods to display common dialog to the user.
- * \inqmlmodule Knut
  * \ingroup Utilities
  *
  * The `UserDialog` singleton provides methods to display common dialog that could be used in

--- a/src/core/utils.cpp
+++ b/src/core/utils.cpp
@@ -25,7 +25,6 @@ namespace Core {
 /*!
  * \qmltype Utils
  * \brief Singleton with utility methods.
- * \inqmlmodule Knut
  * \ingroup Utilities
  *
  * The `Utils` singleton implements some utility methods useful for scripts.

--- a/src/rccore/data.cpp
+++ b/src/rccore/data.cpp
@@ -16,7 +16,6 @@ namespace RcCore {
 /*!
  * \qmltype Asset
  * \brief Description of a RC file asset.
- * \inqmlmodule Knut
  * \ingroup RcDocument
  * \sa RcFile
  */
@@ -37,7 +36,6 @@ namespace RcCore {
 /*!
  * \qmltype ToolBarItem
  * \brief Description of a RC file toolbar item.
- * \inqmlmodule Knut
  * \ingroup RcDocument
  * \sa RcFile
  */
@@ -53,7 +51,6 @@ namespace RcCore {
 /*!
  * \qmltype ToolBar
  * \brief Description of a RC file toolbar.
- * \inqmlmodule Knut
  * \ingroup RcDocument
  * \sa RcFile
  */
@@ -77,7 +74,6 @@ namespace RcCore {
 /*!
  * \qmltype Widget
  * \brief Description of a RC file widget.
- * \inqmlmodule Knut
  * \ingroup RcDocument
  * \sa RcFile
  */
@@ -109,7 +105,6 @@ namespace RcCore {
 /*!
  * \qmltype MenuItem
  * \brief Description of a RC file menu item.
- * \inqmlmodule Knut
  * \ingroup RcDocument
  * \sa RcFile
  */
@@ -141,7 +136,6 @@ namespace RcCore {
 /*!
  * \qmltype Menu
  * \brief Description of a RC file menu.
- * \inqmlmodule Knut
  * \ingroup RcDocument
  * \sa RcFile
  */
@@ -161,7 +155,6 @@ namespace RcCore {
 /*!
  * \qmltype Shortcut
  * \brief Description of a RC file shortcut.
- * \inqmlmodule Knut
  * \ingroup RcDocument
  * \sa RcFile
  */
@@ -177,7 +170,6 @@ namespace RcCore {
 /*!
  * \qmltype Action
  * \brief Description of a RC file action.
- * \inqmlmodule Knut
  * \ingroup RcDocument
  * \sa RcFile
  */
@@ -217,7 +209,6 @@ namespace RcCore {
 /*!
  * \qmltype String
  * \brief Description of a RC file string.
- * \inqmlmodule Knut
  * \ingroup RcDocument
  * \sa RcFile
  */

--- a/src/rccore/ribbon.cpp
+++ b/src/rccore/ribbon.cpp
@@ -17,7 +17,6 @@ namespace RcCore {
 /*!
  * \qmltype RibbonElement
  * \brief An item in the ribbon (button, separator...).
- * \inqmlmodule Knut
  * \ingroup RcDocument
  * \sa Ribbon
  */
@@ -57,7 +56,6 @@ namespace RcCore {
 /*!
  * \qmltype RibbonPanel
  * \brief An panel (group of elements) in the ribbon.
- * \inqmlmodule Knut
  * \ingroup RcDocument
  * \sa Ribbon
  */
@@ -77,7 +75,6 @@ namespace RcCore {
 /*!
  * \qmltype RibbonCategory
  * \brief A tab (made of panels) in the ribbon.
- * \inqmlmodule Knut
  * \ingroup RcDocument
  * \sa Ribbon
  */
@@ -105,7 +102,6 @@ namespace RcCore {
 /*!
  * \qmltype RibbonContext
  * \brief A context (tabs with a title) in the ribbon.
- * \inqmlmodule Knut
  * \ingroup RcDocument
  * \sa Ribbon
  */
@@ -125,7 +121,6 @@ namespace RcCore {
 /*!
  * \qmltype RibbonMenu
  * \brief A menu showing when clicking on the left/top icon in the ribbon.
- * \inqmlmodule Knut
  * \ingroup RcDocument
  * \sa Ribbon
  */
@@ -153,7 +148,6 @@ namespace RcCore {
 /*!
  * \qmltype Ribbon
  * \brief The ribbon description (not everything is read yet).
- * \inqmlmodule Knut
  * \ingroup RcDocument
  * \sa RcFile
  *

--- a/tools/cpp2doc/sourceparser.cpp
+++ b/tools/cpp2doc/sourceparser.cpp
@@ -103,6 +103,10 @@ Data::TypeBlock SourceParser::parseType(QTextStream &stream, QString line)
             parseBlock(line, currentType);
     }
 
+    if (currentType.qmlModule.isEmpty()) {
+        currentType.qmlModule = "Knut";
+    }
+
     return currentType;
 }
 


### PR DESCRIPTION
Fixes KDAB#50

This is a follow up of #49.
- remove all "\inqmlmodule in the code documentation
- add an empty string into Script module to be able to use it, just in case for later