### PR TITLE
feat: Scheme syntax highlighting for TreeSitter

### DIFF
--- a/src/gui/treesitterinspector.h
+++ b/src/gui/treesitterinspector.h
@@ -13,6 +13,7 @@
 #include "treesitter/parser.h"
 #include "treesittertreemodel.h"
 
+#include <KSyntaxHighlighting/SyntaxHighlighter>
 #include <QDialog>
 #include <QSyntaxHighlighter>
 
@@ -31,7 +32,7 @@ namespace Ui {
     class TreeSitterInspector;
 }
 
-class QueryErrorHighlighter : public QSyntaxHighlighter
+class QueryErrorHighlighter : public KSyntaxHighlighting::SyntaxHighlighter
 {
     Q_OBJECT
 public:


### PR DESCRIPTION
This uses KSyntaxHighlighting::SyntaxHighlighter to enable a
scheme-based syntax highlighting on the TreeSitterInspector.

This still has a few issues, as e.g. #eq? produces a strange
highlighting result and certain keywords are marked up without reason.
But it's still a good improvement from no syntax highlighting.

Part of #62.
