### PR TITLE
feat: Handle QTextEdit in the ScriptDialogItem

### DIFF
--- a/examples/ex_script_dialog.qml
+++ b/examples/ex_script_dialog.qml
@@ -26,6 +26,12 @@ ScriptDialog {
         // Defined the possible choices for the comboBoxfine
         data.comboBoxModel = ["1", "2", "3"]
         data.comboBox = "2"
+        // Initialize textEdit and plainTextEdit with example text and syntax
+        data.textEdit = "// Example C++ code\nint main() {\n    return 0;\n}"
+        data.textEditSyntax = "cpp"
+        data.plainTextEdit = "// Example JavaScript code\nfunction hello() {\n    console.log('Hello');\n}"
+        data.plainTextEditSyntax = "js"
+
     }
 
     function showData() {
@@ -36,6 +42,8 @@ ScriptDialog {
         Message.log("SpinBox data: " + data.spinBox)
         Message.log("DoubleSpinBox data: " + data.doubleSpinBox)
         Message.log("ComboBox data: " + data.comboBox)
+        Message.log("TextEdit data: " + data.textEdit)
+        Message.log("PlainTextEdit data: " + data.plainTextEdit)
     }
 
     // Function called when the user click on the OK button
@@ -46,21 +54,21 @@ ScriptDialog {
 
     // Function called when the user click on the Cancel button
     onRejected: {
-         // Logging when the Cancel button is clicked
+        // Logging when the Cancel button is clicked
         Message.log("Cancel button is clicked")
     }
 
     // Function called when a button is clicked
-    onClicked:(name)=>{
-        if (name == "pushButton"){
+    onClicked: (name) => {
+        if (name === "pushButton") {
             Message.log("PushButton is clicked")
-        }
-        else if (name == "toolButton"){
+        } else if (name === "toolButton") {
             Message.log("ToolButton is clicked")
         }
     }
     // Function to automatically test the script, useful for automated testing
     // It runs the script without user interaction
+
     function test_script() {
         showData();
         close();

--- a/examples/ex_script_dialog.ui
+++ b/examples/ex_script_dialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>407</width>
-    <height>374</height>
+    <width>291</width>
+    <height>471</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -25,6 +25,23 @@
     <widget class="QPushButton" name="pushButton">
      <property name="text">
       <string>PushButton</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="QLabel" name="label_9">
+     <property name="text">
+      <string>toolButton</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="1">
+    <widget class="QToolButton" name="toolButton">
+     <property name="enabled">
+      <bool>true</bool>
+     </property>
+     <property name="text">
+      <string>ToolButton</string>
      </property>
     </widget>
    </item>
@@ -100,47 +117,37 @@
    <item row="7" column="1">
     <widget class="QComboBox" name="comboBox"/>
    </item>
-   <item row="8" column="1">
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>249</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item row="12" column="0">
+   <item row="11" column="0">
     <widget class="QLabel" name="label_3">
      <property name="text">
       <string>dialogButtonBox</string>
      </property>
     </widget>
    </item>
-   <item row="12" column="1">
+   <item row="11" column="1">
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="standardButtons">
       <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
      </property>
     </widget>
    </item>
-   <item row="1" column="1">
-    <widget class="QToolButton" name="toolButton">
-     <property name="enabled">
-      <bool>true</bool>
-     </property>
+   <item row="8" column="1">
+    <widget class="QTextEdit" name="textEdit"/>
+   </item>
+   <item row="9" column="1">
+    <widget class="QPlainTextEdit" name="plainTextEdit"/>
+   </item>
+   <item row="8" column="0">
+    <widget class="QLabel" name="label_10">
      <property name="text">
-      <string>ToolButton</string>
+      <string>textEdit</string>
      </property>
     </widget>
    </item>
-   <item row="1" column="0">
-    <widget class="QLabel" name="label_9">
+   <item row="9" column="0">
+    <widget class="QLabel" name="label_11">
      <property name="text">
-      <string>toolButton</string>
+      <string>plainTextEdit</string>
      </property>
     </widget>
    </item>

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -117,6 +117,7 @@ target_link_libraries(
   PUBLIC nlohmann_json::nlohmann_json
          pugixml::pugixml
          kdalgorithms
+         KF5SyntaxHighlighting
          Qt::Core
          Qt::CorePrivate
          Qt::Qml

--- a/src/core/scriptdialogitem.h
+++ b/src/core/scriptdialogitem.h
@@ -18,6 +18,11 @@
 #include <vector>
 
 class ScriptProgressDialog;
+class QTextDocument;
+
+namespace KSyntaxHighlighting {
+class SyntaxHighlighter;
+}
 
 namespace Core {
 
@@ -84,6 +89,8 @@ private:
     static QObject *atChild(QQmlListProperty<QObject> *list, qsizetype index);
     static qsizetype countChildren(QQmlListProperty<QObject> *list);
     static void clearChildren(QQmlListProperty<QObject> *list);
+
+    void applySyntaxHighlighting(QTextDocument *document, const QString &syntax);
 
 private:
     DynamicObject *m_data;


### PR DESCRIPTION
Fixes KDAB#27
to use the syntax highlighting of the "data.foo" widget, just use the name of the extension like "cpp", "js" or "py" in the "data.fooSyntax" property