### PR TITLE
feat: add a find in files API to `Project`

### DIFF
--- a/docs/API/knut/project.md
+++ b/docs/API/knut/project.md
@@ -22,7 +22,9 @@ import Knut
 |array&lt;string> |**[allFilesWithExtension](#allFilesWithExtension)**(string extension, PathType type = RelativeToRoot)|
 |array&lt;string> |**[allFilesWithExtensions](#allFilesWithExtensions)**(array&lt;string> extensions, PathType type = RelativeToRoot)|
 ||**[closeAll](#closeAll)**()|
+|array&lt;object> |**[findInFiles](#findInFiles)**(const QString &pattern)|
 |[Document](../knut/document.md) |**[get](#get)**(string fileName)|
+|bool |**[isFindInFilesAvailable](#isFindInFilesAvailable)**()|
 |[Document](../knut/document.md) |**[open](#open)**(string fileName)|
 ||**[openPrevious](#openPrevious)**(int index = 1)|
 ||**[saveAllDocuments](#saveAllDocuments)**()|
@@ -75,6 +77,25 @@ Returns all files with an extension from `extensions` in the current project.
 
 Close all documents. If the document has some changes, save the changes.
 
+#### <a name="findInFiles"></a>array&lt;object> **findInFiles**(const QString &pattern)
+
+Search for a regex pattern in all files of the current project using ripgrep.
+Returns a list of results (QVariantMaps) with the document name and position ("file", "line", "column").
+
+Example usage in QML:
+
+```js
+let findResults = Project.findInFiles("foo");
+for (let result of findResults) {
+    Message.log("Filename: " + result.file);
+    Message.log("Line: " + result.line);
+    Message.log("Column" + result.column);
+}
+```
+
+Note: The method uses ripgrep (rg) for searching, which must be installed and accessible in PATH.
+The `pattern` parameter should be a valid regular expression.
+
 #### <a name="get"></a>[Document](../knut/document.md) **get**(string fileName)
 
 Gets the document for the given `fileName`. If the document is not opened yet, open it. If the document
@@ -85,6 +106,10 @@ If the document does not exist, creates a new document (but don't save it yet).
 
 !!! note
     This command does not change the current document.
+
+#### <a name="isFindInFilesAvailable"></a>bool **isFindInFilesAvailable**()
+
+Checks if the ripgrep (rg) command-line tool is available on the system.
 
 #### <a name="open"></a>[Document](../knut/document.md) **open**(string fileName)
 

--- a/src/core/project.h
+++ b/src/core/project.h
@@ -53,6 +53,8 @@ public:
                                                   Core::Project::PathType type = RelativeToRoot);
     Q_INVOKABLE QStringList allFilesWithExtensions(const QStringList &extensions,
                                                    Core::Project::PathType type = RelativeToRoot);
+    Q_INVOKABLE QVariantList findInFiles(const QString &pattern) const;
+    Q_INVOKABLE bool isFindInFilesAvailable() const;
 
 public slots:
     Core::Document *get(const QString &fileName);

--- a/test_data/tst_project.qml
+++ b/test_data/tst_project.qml
@@ -33,4 +33,34 @@ Script {
         var rcdoc = Project.open("MFC_UpdateGUI.rc")
         compare(rcdoc.type, Document.Rc)
     }
+
+    function test_findInFiles() {
+        if(Project.isFindInFilesAvailable()) {
+        let simplePattern = "CTutorialApp::InitInstance()"
+        let simpleResults = Project.findInFiles(simplePattern)
+
+            compare(simpleResults.length, 2)
+
+            simpleResults.sort((a, b) => a.file.localeCompare(b.file));
+
+            compare(simpleResults[0].file, Project.root + "/TutorialApp.cpp")
+            compare(simpleResults[0].line, 21)
+            compare(simpleResults[0].column, 6)
+            compare(simpleResults[1].file, Project.root + "/TutorialDlg.h")
+            compare(simpleResults[1].line, 10)
+            compare(simpleResults[1].column, 9)
+
+            let multilinePattern = "m_VSliderBar\\.SetRange\\(0,\\s*100,\\s*TRUE\\);\\s*m_VSliderBar\\.SetPos\\(50\\);";
+            let multilineResults = Project.findInFiles(multilinePattern)
+
+            compare(multilineResults.length, 1)
+
+            compare(multilineResults[0].file, Project.root + "/TutorialDlg.cpp")
+            compare(multilineResults[0].line, 65)
+            compare(multilineResults[0].column, 3)
+        }
+        else {
+            Message.warning("Ripgrep (rg) isn't available on the system")
+        }
+    }
 }


### PR DESCRIPTION
The methode return a list of document + position of the find items.
The method uses ripgrep (rg) for searching, which must be installed and accessible in PATH.
The `pattern` parameter should be a valid regular expression.
Fixes KDAB#21