### PR TITLE
fix: allows describing type documentation with nested brackets and commas

### DIFF
--- a/docs/API/knut/classsymbol.md
+++ b/docs/API/knut/classsymbol.md
@@ -14,10 +14,10 @@ import Knut
 
 | | Name |
 |-|-|
-|vector<[Symbol](../knut/symbol.md)>|**[members](#members)**|
+|vector&lt;[Symbol](../knut/symbol.md)>|**[members](#members)**|
 
 ## Property Documentation
 
-#### <a name="members"></a>vector<[Symbol](../knut/symbol.md)> **members**
+#### <a name="members"></a>vector&lt;[Symbol](../knut/symbol.md)> **members**
 
 Returns the list of members (both data and functions) of this class.

--- a/docs/API/knut/dataexchange.md
+++ b/docs/API/knut/dataexchange.md
@@ -11,7 +11,7 @@ import Knut
 | | Name |
 |-|-|
 |string|**[className](#className)**|
-|list<[DataExchangeEntry](../knut/dataexchangeentry.md)>|**[entries](#entries)**|
+|list&lt;[DataExchangeEntry](../knut/dataexchangeentry.md)>|**[entries](#entries)**|
 |[RangeMark](../knut/rangemark.md)|**[range](#range)**|
 
 ## Detailed Description
@@ -24,7 +24,7 @@ The `DataExchange` object represents the data contained in the MFC `DoDataExchan
 
 The name of the class this data exchange belongs to.
 
-#### <a name="entries"></a>list<[DataExchangeEntry](../knut/dataexchangeentry.md)> **entries**
+#### <a name="entries"></a>list&lt;[DataExchangeEntry](../knut/dataexchangeentry.md)> **entries**
 
 All entries found in the data exchange method as `DataExchangeEntry`.
 

--- a/docs/API/knut/functionsymbol.md
+++ b/docs/API/knut/functionsymbol.md
@@ -14,12 +14,12 @@ import Knut
 
 | | Name |
 |-|-|
-|vector<[FunctionArgument](../knut/functionargument.md)>|**[arguments](#arguments)**|
+|vector&lt;[FunctionArgument](../knut/functionargument.md)>|**[arguments](#arguments)**|
 |string|**[returnType](#returnType)**|
 
 ## Property Documentation
 
-#### <a name="arguments"></a>vector<[FunctionArgument](../knut/functionargument.md)> **arguments**
+#### <a name="arguments"></a>vector&lt;[FunctionArgument](../knut/functionargument.md)> **arguments**
 
 Returns the list of arguments being passed to this function.
 

--- a/docs/API/knut/messagemap.md
+++ b/docs/API/knut/messagemap.md
@@ -11,7 +11,7 @@ import Knut
 | | Name |
 |-|-|
 |string|**[className](#className)**|
-|list<[MessageMapEntry](../knut/messagemapentry.md)>|**[entries](#entries)**|
+|list&lt;[MessageMapEntry](../knut/messagemapentry.md)>|**[entries](#entries)**|
 |bool|**[isValid](#isValid)**|
 |[RangeMark](../knut/rangemark.md)|**[range](#range)**|
 |string|**[superClass](#superClass)**|
@@ -21,7 +21,7 @@ import Knut
 | | Name |
 |-|-|
 |[MessageMapEntry](../knut/messagemapentry.md) |**[get](#get)**(string name)|
-|list<[MessageMapEntry](../knut/messagemapentry.md)> |**[getAll](#getAll)**(string name)|
+|list&lt;[MessageMapEntry](../knut/messagemapentry.md)> |**[getAll](#getAll)**(string name)|
 
 ## Detailed Description
 
@@ -33,7 +33,7 @@ The `MessageMap` object represents the data contained in the MFC MessageMap.
 
 The name of the class this message map belongs to.
 
-#### <a name="entries"></a>list<[MessageMapEntry](../knut/messagemapentry.md)> **entries**
+#### <a name="entries"></a>list&lt;[MessageMapEntry](../knut/messagemapentry.md)> **entries**
 
 All entries found in the MessageMap as `MessageMapEntry`.
 
@@ -58,6 +58,6 @@ The name of the super class this class inherits from.
 Gets the first entry with the given `name`.
 If no entry could be found, isValid will be false on the resulting MessageMapEntry.
 
-#### <a name="getAll"></a>list<[MessageMapEntry](../knut/messagemapentry.md)> **getAll**(string name)
+#### <a name="getAll"></a>list&lt;[MessageMapEntry](../knut/messagemapentry.md)> **getAll**(string name)
 
 Gets all entries with the given `name`.

--- a/docs/API/knut/messagemapentry.md
+++ b/docs/API/knut/messagemapentry.md
@@ -12,7 +12,7 @@ import Knut
 |-|-|
 |bool|**[isValid](#isValid)**|
 |string|**[name](#name)**|
-|list<[RangeMark](../knut/rangemark.md)>|**[parameters](#parameters)**|
+|list&lt;[RangeMark](../knut/rangemark.md)>|**[parameters](#parameters)**|
 |[RangeMark](../knut/rangemark.md)|**[range](#range)**|
 
 ## Detailed Description
@@ -35,7 +35,7 @@ Please note that an entry that has been deleted may still be valid, but all its 
 
 The name of the entry.
 
-#### <a name="parameters"></a>list<[RangeMark](../knut/rangemark.md)> **parameters**
+#### <a name="parameters"></a>list&lt;[RangeMark](../knut/rangemark.md)> **parameters**
 
 A list of `RangeMark` instances referring to each parameter of the entry.
 

--- a/docs/API/knut/querymatch.md
+++ b/docs/API/knut/querymatch.md
@@ -18,8 +18,8 @@ import Knut
 | | Name |
 |-|-|
 |[RangeMark](../knut/rangemark.md) |**[get](#get)**(string name)|
-|vector<[RangeMark](../knut/rangemark.md)> |**[getAll](#getAll)**(string name)|
-|vector<[RangeMark](../knut/rangemark.md)> |**[getAllInRange](#getAllInRange)**(string name, [RangeMark](../knut/rangemark.md) range)|
+|vector&lt;[RangeMark](../knut/rangemark.md)> |**[getAll](#getAll)**(string name)|
+|vector&lt;[RangeMark](../knut/rangemark.md)> |**[getAllInRange](#getAllInRange)**(string name, [RangeMark](../knut/rangemark.md) range)|
 |[RangeMark](../knut/rangemark.md) |**[getAllJoined](#getAllJoined)**(string name)|
 |[RangeMark](../knut/rangemark.md) |**[getInRange](#getInRange)**(string name, [RangeMark](../knut/rangemark.md) range)|
 |array&lt;[QueryMatch](../knut/querymatch.md)> |**[queryIn](#queryIn)**(capture, query)|
@@ -79,11 +79,11 @@ match.get("parameter-list").replace("(int myParameter)");
 
 See the [RangeMark](rangemark.md) documentation for more information.
 
-#### <a name="getAll"></a>vector<[RangeMark](../knut/rangemark.md)> **getAll**(string name)
+#### <a name="getAll"></a>vector&lt;[RangeMark](../knut/rangemark.md)> **getAll**(string name)
 
 Returns all ranges that are covered by the captures of the given `name`
 
-#### <a name="getAllInRange"></a>vector<[RangeMark](../knut/rangemark.md)> **getAllInRange**(string name, [RangeMark](../knut/rangemark.md) range)
+#### <a name="getAllInRange"></a>vector&lt;[RangeMark](../knut/rangemark.md)> **getAllInRange**(string name, [RangeMark](../knut/rangemark.md) range)
 
 Returns all ranges that are covered by the captures of the given `name` in the given `range`.
 

--- a/tools/cpp2doc/docwriter.cpp
+++ b/tools/cpp2doc/docwriter.cpp
@@ -229,7 +229,9 @@ void DocWriter::writeTypeFile(const Data::TypeBlock &type)
 
     if (!type.description.isEmpty()) {
         stream << "\n## Detailed Description\n\n";
-        stream << type.description;
+        QString description = type.description;
+        description.replace("<", "&lt;");
+        stream << description;
     }
 
     if (properties.size()) {
@@ -276,7 +278,6 @@ void DocWriter::writeTypeFile(const Data::TypeBlock &type)
 
     buffer.close();
     auto text = buffer.data();
-    text.replace("array<", "array&lt;");
     file.write(text);
 }
 
@@ -371,5 +372,6 @@ QString DocWriter::typeToString(QString type) const
             index = type.indexOf(key, index + key.length());
         }
     }
+    type.replace("<", "&lt;");
     return type;
 }

--- a/tools/cpp2doc/sourceparser.cpp
+++ b/tools/cpp2doc/sourceparser.cpp
@@ -141,7 +141,7 @@ static auto parseMethodDefinition(const QString &line)
         QString qmlType;
     } result;
 
-    static QRegularExpression regexp(R"(^(?:([\w<>]+) )?(\w+)::(\w+)\((.*)\)$)");
+    static QRegularExpression regexp(R"(^(?:([\w<>, ]+) )?(\w+)::(\w+)\((.*)\)$)");
     auto match = regexp.match(line);
     result.method.returnType = match.captured(1);
     result.qmlType = match.captured(2);


### PR DESCRIPTION
makes documentation generation easier by allowing writing types with nested angle brackets like `array<map<string, int>>`