### PR TITLE
use source location for the LOG

### DIFF
--- a/src/core/astnode.cpp
+++ b/src/core/astnode.cpp
@@ -50,7 +50,7 @@ bool AstNode::isValid() const
 std::optional<treesitter::Node> AstNode::node() const
 {
     if (!isValid()) {
-        spdlog::warn("AstNode is invalid");
+        spdlog::warn("{}: AstNode is invalid", FUNCTION_NAME);
         return std::nullopt;
     }
 

--- a/src/core/classsymbol.cpp
+++ b/src/core/classsymbol.cpp
@@ -40,7 +40,7 @@ QList<Symbol *> ClassSymbol::findMembers() const
         }
         return members;
     }
-    spdlog::warn("Parent of CppClass {} is not an CodeDocument!", m_name);
+    spdlog::warn("{}: Parent of CppClass {} is not an CodeDocument!", FUNCTION_NAME, m_name);
     return {};
 }
 

--- a/src/core/codedocument_p.cpp
+++ b/src/core/codedocument_p.cpp
@@ -50,12 +50,12 @@ std::optional<treesitter::Tree> &TreeSitterHelper::syntaxTree()
     if (!m_tree) {
         auto &parser = this->parser();
         if (!parser.setIncludedRanges(m_document->includedRanges())) {
-            spdlog::warn("TreeSitterHelper::syntaxTree: Unable to set the included ranges on the treesitter parser!");
+            spdlog::warn("{}: Unable to set the included ranges on the treesitter parser!", FUNCTION_NAME);
             parser.setIncludedRanges({});
         }
         m_tree = parser.parseString(m_document->text());
         if (!m_tree) {
-            spdlog::warn("CodeDocument::syntaxTree: Failed to parse document {}!", m_document->fileName());
+            spdlog::warn("{}: Failed to parse document {}!", FUNCTION_NAME, m_document->fileName());
         }
     }
     return m_tree;
@@ -67,8 +67,8 @@ std::shared_ptr<treesitter::Query> TreeSitterHelper::constructQuery(const QStrin
     try {
         tsQuery = std::make_shared<treesitter::Query>(parser().language(), query);
     } catch (treesitter::Query::Error &error) {
-        spdlog::error("CodeDocument::constructQuery: Failed to parse query `{}` error: {} at: {}", query,
-                      error.description, error.utf8_offset);
+        spdlog::error("{}: Failed to parse query `{}` error: {} at: {}", FUNCTION_NAME, query, error.description,
+                      error.utf8_offset);
         return {};
     }
     return tsQuery;

--- a/src/core/dir.cpp
+++ b/src/core/dir.cpp
@@ -56,7 +56,7 @@ Dir::~Dir() = default;
  */
 QString Dir::toNativeSeparators(const QString &pathName)
 {
-    LOG("Dir::toNativeSeparators", pathName);
+    LOG(pathName);
     return QDir::toNativeSeparators(pathName);
 }
 
@@ -65,7 +65,7 @@ QString Dir::toNativeSeparators(const QString &pathName)
  */
 QString Dir::fromNativeSeparators(const QString &pathName)
 {
-    LOG("Dir::fromNativeSeparators", pathName);
+    LOG(pathName);
     return QDir::fromNativeSeparators(pathName);
 }
 
@@ -74,7 +74,7 @@ QString Dir::fromNativeSeparators(const QString &pathName)
  */
 bool Dir::isRelativePath(const QString &path)
 {
-    LOG("Dir::isRelativePath", path);
+    LOG(path);
     return QDir::isRelativePath(path);
 }
 
@@ -83,7 +83,7 @@ bool Dir::isRelativePath(const QString &path)
  */
 bool Dir::isAbsolutePath(const QString &path)
 {
-    LOG("Dir::isAbsolutePath", path);
+    LOG(path);
     return !isRelativePath(path);
 }
 
@@ -94,7 +94,7 @@ QChar Dir::separator() const
 
 bool Dir::setCurrentPath(const QString &path)
 {
-    LOG("Dir::setCurrentPath", path);
+    LOG(path);
     if (path != QDir::currentPath()) {
         if (QDir::setCurrent(path)) {
             emit currentPathChanged(path);
@@ -150,13 +150,13 @@ QString Dir::tempPath() const
  */
 bool Dir::match(const QStringList &filters, const QString &fileName)
 {
-    LOG("Dir::match", filters, fileName);
+    LOG(filters, fileName);
     return QDir::match(filters, fileName);
 }
 
 bool Dir::match(const QString &filter, const QString &fileName)
 {
-    LOG("Dir::match", filter, fileName);
+    LOG(filter, fileName);
     return QDir::match(filter, fileName);
 }
 
@@ -165,7 +165,7 @@ bool Dir::match(const QString &filter, const QString &fileName)
  */
 QString Dir::cleanPath(const QString &path)
 {
-    LOG("Dir::cleanPath", path);
+    LOG(path);
     return QDir::cleanPath(path);
 }
 
@@ -174,7 +174,7 @@ QString Dir::cleanPath(const QString &path)
  */
 QDirValueType Dir::create(const QString &path)
 {
-    LOG("Dir::create", path);
+    LOG(path);
     return QDirValueType(path);
 }
 

--- a/src/core/document.cpp
+++ b/src/core/document.cpp
@@ -73,7 +73,7 @@ const QString &Document::fileName() const
 
 void Document::setFileName(const QString &newFileName)
 {
-    LOG("Document::setFileName", newFileName);
+    LOG(newFileName);
     if (m_fileName == newFileName)
         return;
     load(newFileName);
@@ -144,9 +144,9 @@ void Document::reload()
  */
 bool Document::load(const QString &fileName)
 {
-    LOG("Document::load", fileName);
+    LOG(fileName);
     if (fileName.isEmpty()) {
-        spdlog::warn("Document::load - fileName is empty");
+        spdlog::warn("{}: fileName is empty", FUNCTION_NAME);
         return false;
     }
     if (m_fileName == fileName)
@@ -169,7 +169,7 @@ bool Document::load(const QString &fileName)
  */
 bool Document::save()
 {
-    LOG("Document::save");
+    LOG();
     return saveAs(m_fileName);
 }
 
@@ -180,9 +180,9 @@ bool Document::save()
  */
 bool Document::saveAs(const QString &fileName)
 {
-    LOG("Document::saveAs", fileName);
+    LOG(fileName);
     if (fileName.isEmpty()) {
-        spdlog::error("Document::saveAs - fileName is empty");
+        spdlog::error("{}: fileName is empty", FUNCTION_NAME);
         return false;
     }
 
@@ -217,7 +217,7 @@ bool Document::saveAs(const QString &fileName)
  */
 void Document::close()
 {
-    LOG("Document::close");
+    LOG();
     if (m_fileName.isEmpty())
         return;
     if (m_hasChanged)

--- a/src/core/file.cpp
+++ b/src/core/file.cpp
@@ -37,7 +37,7 @@ File::~File() = default;
  */
 bool File::copy(const QString &fileName, const QString &newName)
 {
-    LOG("File::copy", fileName, newName);
+    LOG(fileName, newName);
     return QFile::copy(fileName, newName);
 }
 
@@ -46,7 +46,7 @@ bool File::copy(const QString &fileName, const QString &newName)
  */
 bool File::exists(const QString &fileName)
 {
-    LOG("File::exists", fileName);
+    LOG(fileName);
     return QFile::exists(fileName);
 }
 
@@ -55,7 +55,7 @@ bool File::exists(const QString &fileName)
  */
 bool File::remove(const QString &fileName)
 {
-    LOG("File::remove", fileName);
+    LOG(fileName);
     return QFile::remove(fileName);
 }
 
@@ -64,7 +64,7 @@ bool File::remove(const QString &fileName)
  */
 bool File::rename(const QString &oldName, const QString &newName)
 {
-    LOG("File::rename", oldName, newName);
+    LOG(oldName, newName);
     return QFile::rename(oldName, newName);
 }
 
@@ -73,7 +73,7 @@ bool File::rename(const QString &oldName, const QString &newName)
  */
 bool File::touch(const QString &fileName)
 {
-    LOG("File::touch", fileName);
+    LOG(fileName);
     QFile file(fileName);
     return file.open(QFile::Append);
 }
@@ -83,7 +83,7 @@ bool File::touch(const QString &fileName)
  */
 QString File::readAll(const QString &fileName)
 {
-    LOG("File::readAll", fileName);
+    LOG(fileName);
     QFile file(fileName);
     if (file.open(QFile::ReadOnly | QIODevice::Text)) {
         QTextStream stream(&file);

--- a/src/core/fileinfo.cpp
+++ b/src/core/fileinfo.cpp
@@ -36,7 +36,7 @@ FileInfo::~FileInfo() = default;
  */
 bool FileInfo::exists(const QString &file)
 {
-    LOG("FileInfo::exists", file);
+    LOG(file);
     return QFileInfo::exists(file);
 }
 
@@ -45,7 +45,7 @@ bool FileInfo::exists(const QString &file)
  */
 QFileInfoValueType FileInfo::create(const QString &file)
 {
-    LOG("FileInfo::create", file);
+    LOG(file);
     return QFileInfoValueType(file);
 }
 

--- a/src/core/imagedocument.cpp
+++ b/src/core/imagedocument.cpp
@@ -26,7 +26,7 @@ QImage ImageDocument::image() const
 bool ImageDocument::doSave(const QString &fileName)
 {
     Q_UNUSED(fileName)
-    spdlog::error("ImageDocument::doSave - not implemented yet");
+    spdlog::error("{}: not implemented yet", FUNCTION_NAME);
     return false;
 }
 

--- a/src/core/jsondocument.cpp
+++ b/src/core/jsondocument.cpp
@@ -56,7 +56,7 @@ bool JsonDocument::loadJsonData(const QString &fileName)
  */
 bool JsonDocument::hasValue(const QString &path) const
 {
-    LOG("JsonDocument::hasValue", path);
+    LOG(path);
     return Utils::hasJsonValue(m_jsonData, path);
 }
 
@@ -67,9 +67,9 @@ bool JsonDocument::hasValue(const QString &path) const
 QVariant JsonDocument::value(const QString &path, const QVariant &defaultValue) const
 {
     if (defaultValue.isValid())
-        LOG("JsonDocument::value", path, defaultValue);
+        LOG(path, defaultValue);
     else
-        LOG("JsonDocument::value", path);
+        LOG(path);
 
     // Special cases
     if (path == Settings::RcAssetColors || path == Settings::RcAssetFlags || path == Settings::RcDialogFlags) {
@@ -98,7 +98,7 @@ QVariant JsonDocument::value(const QString &path, const QVariant &defaultValue) 
  */
 bool JsonDocument::setValue(const QString &path, const QVariant &value)
 {
-    LOG("JsonDocument::setValue", path, value);
+    LOG(path, value);
 
     Utils::SetJsonValueStatus status = Utils::setJsonValue(m_jsonData, path, value);
     switch (status) {

--- a/src/core/knutcore.cpp
+++ b/src/core/knutcore.cpp
@@ -100,7 +100,7 @@ bool KnutCore::process(const QStringList &arguments)
         if (pathDir.exists()) {
             Project::instance()->setRoot(rootDir);
         } else {
-            spdlog::error("KnutCore::process - Root directory: {}, does not exist. Cannot open a new project!",
+            spdlog::error("{} - Root directory: {}, does not exist. Cannot open a new project!", FUNCTION_NAME,
                           pathDir.absolutePath());
             return false;
         }
@@ -131,7 +131,7 @@ bool KnutCore::process(const QStringList &arguments)
         try {
             jsonData = json::parse(jsonDataStr.toStdString());
         } catch (const json::parse_error &ex) {
-            spdlog::error("JSON parsing error at byte {}: {}", ex.byte, ex.what());
+            spdlog::error("{}: JSON parsing error at byte {}: {}", FUNCTION_NAME, ex.byte, ex.what());
             return false;
         }
     }

--- a/src/core/logger.h
+++ b/src/core/logger.h
@@ -1,4 +1,4 @@
-/*
+﻿/*
   This file is part of Knut.
 
   SPDX-FileCopyrightText: 2024 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
@@ -29,13 +29,17 @@
 /**
  * Log a method, with all its parameters.
  */
-#define LOG(name, ...) Core::LoggerObject __loggerObject(name, false, ##__VA_ARGS__)
+#define LOG(...)                                                                                                       \
+    Core::LoggerObject __loggerObject(Core::formatToClassNameFunctionName(std::source_location::current()), false,     \
+                                      ##__VA_ARGS__)
 
 /**
  * Log a method, with all its parameters. If the previous log is also the same method, it will be merged into one
  * operation
  */
-#define LOG_AND_MERGE(name, ...) Core::LoggerObject __loggerObject(name, true, ##__VA_ARGS__)
+#define LOG_AND_MERGE(...)                                                                                             \
+    Core::LoggerObject __loggerObject(Core::formatToClassNameFunctionName(std::source_location::current()), true,      \
+                                      ##__VA_ARGS__)
 
 /**
  * Macro to save the returned value in the historymodel
@@ -211,7 +215,7 @@ private:
 class LoggerObject
 {
 public:
-    explicit LoggerObject(QString name, bool /*unused*/)
+    explicit LoggerObject(QString location, bool /*unused*/)
         : LoggerObject()
     {
         if (!m_canLog)
@@ -226,22 +230,24 @@ public:
         ScriptDialogItem::updateProgress();
 
         if (m_model)
-            m_model->logData(name);
-        log(std::move(name));
+            m_model->logData(location);
+        log(std::move(location));
     }
 
     template <typename... Ts>
-    explicit LoggerObject(QString name, bool merge, Ts... params)
+    explicit LoggerObject(QString location, bool merge, Ts... params)
         : LoggerObject()
     {
         if (!m_canLog)
             return;
+
         if (m_model)
-            m_model->logData(name, merge, params...);
+            m_model->logData(location, merge, params...);
 
         QStringList paramList;
         (paramList.push_back(valueToString(params)), ...);
-        QString result = name + " - " + paramList.join(", ");
+
+        QString result = location + " - " + paramList.join(", ");
         log(std::move(result));
     }
 

--- a/src/core/mark.cpp
+++ b/src/core/mark.cpp
@@ -51,7 +51,7 @@ namespace Core {
 bool MarkPrivate::checkEditor() const
 {
     if (!m_editor) {
-        spdlog::error("Mark::checkEditor - document does not exist anymore");
+        spdlog::error("{}: - document does not exist anymore", FUNCTION_NAME);
         return false;
     }
     return true;
@@ -139,7 +139,7 @@ TextDocument *Mark::document() const
  */
 void Mark::restore() const
 {
-    LOG("Mark::restore");
+    LOG();
     if (isValid()) {
         document()->gotoMark(*this);
     }

--- a/src/core/project.cpp
+++ b/src/core/project.cpp
@@ -88,15 +88,15 @@ const QString &Project::root() const
 
 bool Project::setRoot(const QString &newRoot)
 {
-    LOG("Project::setRoot", newRoot);
+    LOG(newRoot);
     const QDir dir(newRoot);
     if (m_root == dir.absolutePath())
         return true;
 
     if (m_root.isEmpty()) {
-        spdlog::info("Project::setRoot {}", dir.absolutePath());
+        spdlog::info("{}: {}", FUNCTION_NAME, dir.absolutePath());
     } else {
-        spdlog::error("Project::setRoot - can't open a new project");
+        spdlog::error("{}: can't open a new project", FUNCTION_NAME);
         return false;
     }
 
@@ -122,7 +122,7 @@ QStringList Project::allFiles(PathType type) const
     if (m_root.isEmpty())
         return {};
 
-    LOG("Project::allFiles", type);
+    LOG(type);
 
     QDir dir(m_root);
     QDirIterator it(m_root, QDirIterator::Subdirectories);
@@ -150,7 +150,7 @@ QStringList Project::allFilesWithExtension(const QString &extension, PathType ty
     if (m_root.isEmpty())
         return {};
 
-    LOG("Project::allFilesWithExtension", extension, type);
+    LOG(extension, type);
 
     QDir dir(m_root);
     QDirIterator it(m_root, QDirIterator::Subdirectories);
@@ -178,7 +178,7 @@ QStringList Project::allFilesWithExtensions(const QStringList &extensions, PathT
     if (m_root.isEmpty())
         return {};
 
-    LOG("Project::allFilesWithExtensions", extensions, type);
+    LOG(extensions, type);
 
     QDir dir(m_root);
     QDirIterator it(m_root, QDirIterator::Subdirectories);
@@ -289,7 +289,7 @@ Document *Project::getDocument(QString fileName, bool moveToBack)
             m_documents.push_back(doc);
             emit documentsChanged();
         } else {
-            spdlog::error("Project::open {} - unknown document type", fi.suffix());
+            spdlog::error("{}: {} - unknown document type", FUNCTION_NAME, fi.suffix());
             return nullptr;
         }
     }
@@ -309,7 +309,7 @@ Document *Project::getDocument(QString fileName, bool moveToBack)
  */
 Document *Project::get(const QString &fileName)
 {
-    LOG("Project::get", LOG_ARG("path", fileName));
+    LOG(LOG_ARG("path", fileName));
 
     LOG_RETURN("document", getDocument(fileName, false));
 }
@@ -326,7 +326,7 @@ Document *Project::open(const QString &fileName)
     if (m_current && m_current->fileName() == fileName)
         return m_current;
 
-    LOG("Project::open", LOG_ARG("path", fileName));
+    LOG(LOG_ARG("path", fileName));
 
     m_current = getDocument(fileName, true);
     emit currentDocumentChanged(m_current);
@@ -340,7 +340,8 @@ Document *Project::open(const QString &fileName)
  */
 void Project::closeAll()
 {
-    LOG("Project::closeAll");
+    LOG();
+
     for (auto d : std::as_const(m_documents))
         d->close();
 }
@@ -356,7 +357,7 @@ Core::Document *Project::currentDocument() const
  */
 void Project::saveAllDocuments()
 {
-    LOG("Project::saveAllDocuments");
+    LOG();
 
     for (auto d : std::as_const(m_documents)) {
         if (d->hasChanged()) {
@@ -373,7 +374,7 @@ void Project::saveAllDocuments()
  */
 Document *Project::openPrevious(int index)
 {
-    LOG("Project::openPrevious", index);
+    LOG(index);
 
     Q_ASSERT(index < m_documents.size());
     index = m_documents.size() - index - 1;
@@ -403,7 +404,7 @@ Document *Project::openPrevious(int index)
  */
 QVariantList Project::findInFiles(const QString &pattern) const
 {
-    LOG("Project::findInFiles", pattern);
+    LOG(pattern);
 
     QVariantList result;
 

--- a/src/core/qttsdocument.cpp
+++ b/src/core/qttsdocument.cpp
@@ -60,7 +60,7 @@ void QtTsDocument::initializeXml()
  */
 void QtTsDocument::setLanguage(const QString &lang)
 {
-    LOG("QtTsDocument::setLanguage", lang);
+    LOG(lang);
     initializeXml();
     auto ts = m_document.select_node("TS");
     const auto attributeName = "language";
@@ -81,7 +81,7 @@ void QtTsDocument::setLanguage(const QString &lang)
  */
 void QtTsDocument::setSourceLanguage(const QString &lang)
 {
-    LOG("QtTsDocument::setSourceLanguage", lang);
+    LOG(lang);
     initializeXml();
     auto ts = m_document.select_node("TS");
     const auto attributeName = "sourcelanguage";
@@ -125,9 +125,9 @@ void QtTsDocument::addMessage(pugi::xml_node contextChild, const QString &contex
 void QtTsDocument::addMessage(const QString &context, const QString &fileName, const QString &source,
                               const QString &translation, const QString &comment)
 {
-    LOG("QtTsDocument::addMessage", context, fileName, source, translation, comment);
+    LOG(context, fileName, source, translation, comment);
     if (fileName.isEmpty() || source.isEmpty() || context.isEmpty()) {
-        spdlog::error(R"(Location or context or source is empty)");
+        spdlog::error(R"({}: Location or context or source is empty)", FUNCTION_NAME);
     }
 
     initializeXml();
@@ -167,7 +167,7 @@ void QtTsDocument::addMessage(const QString &context, const QString &fileName, c
 void QtTsDocument::setMessageContext(const QString &context, const QString &comment, const QString &source,
                                      const QString &newContext)
 {
-    LOG("QtTsDocument::setContext", context, comment, source, newContext);
+    LOG(context, comment, source, newContext);
 
     initializeXml();
 
@@ -249,7 +249,7 @@ bool QtTsDocument::doLoad(const QString &fileName)
 
     const auto ts = m_document.select_nodes("TS");
     if (ts.empty()) {
-        spdlog::critical("invalid file {}", fileName);
+        spdlog::critical("{}: invalid file {}", FUNCTION_NAME, fileName);
         return false;
     }
 
@@ -330,7 +330,7 @@ QString QtTsMessage::fileName() const
 
 void QtTsMessage::setFileName(const QString &file)
 {
-    LOG("QtTsMessage::setFileName", file);
+    LOG(file);
     m_message.child("location").attribute("filename").set_value(file.toLatin1().constData());
     qobject_cast<QtTsDocument *>(parent())->setHasChanged(true);
     Q_EMIT fileNameChanged();
@@ -343,7 +343,7 @@ int QtTsMessage::line() const
 
 void QtTsMessage::setLine(int line)
 {
-    LOG("QtTsMessage::setLine", line);
+    LOG(line);
     m_message.child("location").attribute("line").set_value(QByteArray::number(line).constData());
     qobject_cast<QtTsDocument *>(parent())->setHasChanged(true);
     Q_EMIT lineChanged();
@@ -356,7 +356,7 @@ QString QtTsMessage::comment() const
 
 void QtTsMessage::setComment(const QString &comment)
 {
-    LOG("QtTsMessage::setComment", comment);
+    LOG(comment);
     m_message.child("comment").set_value(comment.toLatin1().constData());
     qobject_cast<QtTsDocument *>(parent())->setHasChanged(true);
     Q_EMIT commentChanged();
@@ -369,7 +369,7 @@ QString QtTsMessage::source() const
 
 void QtTsMessage::setSource(const QString &source)
 {
-    LOG("QtTsMessage::setSource", source);
+    LOG(source);
     m_message.child("source").set_value(source.toLatin1().constData());
     qobject_cast<QtTsDocument *>(parent())->setHasChanged(true);
     Q_EMIT sourceChanged();
@@ -382,7 +382,7 @@ QString QtTsMessage::translation() const
 
 void QtTsMessage::setTranslation(const QString &translation)
 {
-    LOG("QtTsMessage::setTranslation", translation);
+    LOG(translation);
     m_message.child("translation").remove_attribute("type");
     m_message.child("translation").text().set(translation.toUtf8().constData());
     qobject_cast<QtTsDocument *>(parent())->setHasChanged(true);

--- a/src/core/qtuidocument.cpp
+++ b/src/core/qtuidocument.cpp
@@ -44,7 +44,7 @@ QtUiDocument::~QtUiDocument() = default;
  */
 QtUiWidget *QtUiDocument::findWidget(const QString &name) const
 {
-    LOG("QtUiDocument::findWidget", name);
+    LOG(name);
 
     auto result = kdalgorithms::find_if(m_widgets, [name](QtUiWidget *widget) {
         return widget->name() == name;
@@ -62,10 +62,10 @@ QtUiWidget *QtUiDocument::findWidget(const QString &name) const
  */
 Core::QtUiWidget *QtUiDocument::addWidget(const QString &className, const QString &name, Core::QtUiWidget *parent)
 {
-    LOG("QtUiDocument::addWidget", className, name);
+    LOG(className, name);
 
     if (m_widgets.empty() && parent) {
-        spdlog::error("QtUiDocument::addWidget - adding a widget to a non-root widget is not supported yet.");
+        spdlog::error("{}: adding a widget to a non-root widget is not supported yet.", FUNCTION_NAME);
         return nullptr;
     }
 
@@ -92,7 +92,7 @@ Core::QtUiWidget *QtUiDocument::addWidget(const QString &className, const QStrin
 void QtUiDocument::addCustomWidget(const QString &className, const QString &baseClassName, const QString &header,
                                    bool isContainer)
 {
-    LOG("QtUiDocument::addCustomWidget", className, baseClassName, header, isContainer);
+    LOG(className, baseClassName, header, isContainer);
 
     const auto result = uiWriter()->addCustomWidget(className, baseClassName, header, isContainer);
 
@@ -101,12 +101,10 @@ void QtUiDocument::addCustomWidget(const QString &className, const QString &base
         setHasChanged(true);
         return;
     case Utils::QtUiWriter::AlreadyExists:
-        spdlog::info(R"(QtUiDocument::addCustomWidget - the custom widget '{}' already exists)", className);
+        spdlog::info(R"({}: the custom widget '{}' already exists)", FUNCTION_NAME, className);
         return;
     case Utils::QtUiWriter::InvalidHeader:
-        spdlog::error(
-            R"(QtUiDocument::addCustomWidget - the include '{}' is malformed, should be '<foo.h>' or '"foo.h"')",
-            header);
+        spdlog::error(R"({}: the include '{}' is malformed, should be '<foo.h>' or '"foo.h"')", FUNCTION_NAME, header);
         return;
     case Utils::QtUiWriter::InvalidProperty:
         Q_UNREACHABLE();
@@ -119,7 +117,7 @@ void QtUiDocument::addCustomWidget(const QString &className, const QString &base
  */
 void QtUiDocument::preview() const
 {
-    LOG("QtUiDocument::preview");
+    LOG();
 
     QUiLoader loader;
 
@@ -201,7 +199,7 @@ QString QtUiWidget::name() const
 
 void QtUiWidget::setName(const QString &newName)
 {
-    LOG("QtUiWidget::setName", newName);
+    LOG(newName);
 
     if (newName == name())
         return;
@@ -218,7 +216,7 @@ QString QtUiWidget::className() const
 
 void QtUiWidget::setClassName(const QString &newClassName)
 {
-    LOG("QtUiWidget::setClassName", newClassName);
+    LOG(newClassName);
 
     if (newClassName == className())
         return;
@@ -234,7 +232,7 @@ void QtUiWidget::setClassName(const QString &newClassName)
  */
 QVariant QtUiWidget::getProperty(const QString &name) const
 {
-    LOG("QtUiWidget::getProperty", name);
+    LOG(name);
 
     const QString propertyPath = "property[@name='" % name % "']/*[1]";
     const auto dataNode = m_widget.select_node(propertyPath.toLatin1().constData()).node();
@@ -256,7 +254,7 @@ QVariant QtUiWidget::getProperty(const QString &name) const
         return dataNode.text().as_string();
     }
 
-    spdlog::error(R"(QtUiWidget::property - unknown {} property)", name);
+    spdlog::error(R"({}: unknown {} property)", FUNCTION_NAME, name);
     return {};
 }
 
@@ -275,7 +273,7 @@ QVariant QtUiWidget::getProperty(const QString &name) const
 void QtUiWidget::addProperty(const QString &name, const QVariant &value, const QHash<QString, QString> &attributes,
                              bool userProperty)
 {
-    LOG("QtUiWidget::addProperty", name, value);
+    LOG(name, value);
 
     const auto result = qobject_cast<QtUiDocument *>(parent())->uiWriter()->addWidgetProperty(m_widget, name, value,
                                                                                               attributes, userProperty);
@@ -285,7 +283,7 @@ void QtUiWidget::addProperty(const QString &name, const QVariant &value, const Q
         qobject_cast<QtUiDocument *>(parent())->setHasChanged(true);
         return;
     case Utils::QtUiWriter::InvalidProperty:
-        spdlog::error(R"(QtUiWidget::addProperty - unknown {} type)", value.typeName());
+        spdlog::error(R"({}: unknown {} type)", FUNCTION_NAME, value.typeName());
         return;
     case Utils::QtUiWriter::AlreadyExists:
     case Utils::QtUiWriter::InvalidHeader:

--- a/src/core/querymatch.cpp
+++ b/src/core/querymatch.cpp
@@ -223,7 +223,7 @@ Core::QueryMatchList QueryMatch::queryIn(const QString &capture, const QString &
         if (document) {
             result.append(document->queryInRange(range, query));
         } else {
-            spdlog::warn("QueryMatch::queryIn: RangeMark is not backed by CodeDocument!");
+            spdlog::warn("{}: RangeMark is not backed by CodeDocument!", FUNCTION_NAME);
         }
     }
 

--- a/src/core/rangemark.cpp
+++ b/src/core/rangemark.cpp
@@ -66,7 +66,7 @@ RangeMarkPrivate::RangeMarkPrivate(TextDocument *editor, int start, int end)
 bool RangeMarkPrivate::checkEditor() const
 {
     if (!m_editor) {
-        spdlog::error("RangeMark::checkEditor - document does not exist anymore");
+        spdlog::error("{}: document does not exist anymore", FUNCTION_NAME);
         return false;
     }
     return true;
@@ -75,7 +75,7 @@ bool RangeMarkPrivate::checkEditor() const
 void RangeMarkPrivate::ensureInvariant()
 {
     if (m_start > m_end) {
-        spdlog::warn("RangeMark::ensureInvariant: invariant violated: m_start > m_end ({} > {})", m_start, m_end);
+        spdlog::warn("{}: invariant violated: m_start > m_end ({} > {})", FUNCTION_NAME, m_start, m_end);
         std::swap(m_start, m_end);
     }
 }
@@ -199,15 +199,15 @@ RangeMark RangeMark::join(const RangeMark &other) const
 QString RangeMark::textExcept(const RangeMark &other) const
 {
     if (!isValid()) {
-        spdlog::error("RangeMark::textExcept: invalid range");
+        spdlog::error("{}: invalid range", FUNCTION_NAME);
         return "";
     }
     if (!other.isValid()) {
-        spdlog::debug("RangeMark::textExcept: invalid other range");
+        spdlog::debug("{}: invalid other range", FUNCTION_NAME);
         return text();
     }
     if (document() != other.document()) {
-        spdlog::error("RangeMark::textExcept: different documents");
+        spdlog::error("{}: different documents", FUNCTION_NAME);
         return text();
     }
 

--- a/src/core/rcdocument.cpp
+++ b/src/core/rcdocument.cpp
@@ -123,7 +123,7 @@ QList<RcCore::Action> RcDocument::actions() const
  */
 RcCore::Action RcDocument::action(const QString &id) const
 {
-    LOG("RcDocument::action", id);
+    LOG(id);
 
     // Make sure the action vector is populated by calling actions
     if (isDataValid() && !actions().isEmpty()) {
@@ -143,7 +143,7 @@ RcCore::Action RcDocument::action(const QString &id) const
  */
 RcCore::ActionList RcDocument::actionsFromMenu(const QString &menuId) const
 {
-    LOG("RcDocument::actionsFromMenu", menuId);
+    LOG(menuId);
 
     if (!isDataValid())
         return {};
@@ -163,7 +163,7 @@ RcCore::ActionList RcDocument::actionsFromMenu(const QString &menuId) const
  */
 RcCore::ActionList RcDocument::actionsFromToolbar(const QString &toolBarId) const
 {
-    LOG("RcDocument::actionsFromMenu", toolBarId);
+    LOG(toolBarId);
 
     if (!isDataValid())
         return {};
@@ -190,7 +190,7 @@ QList<RcCore::ToolBar> RcDocument::toolBars() const
  */
 RcCore::ToolBar RcDocument::toolBar(const QString &id) const
 {
-    LOG("RcDocument::toolBar", id);
+    LOG(id);
 
     if (isDataValid()) {
         if (auto tb = data().toolBar(id))
@@ -216,7 +216,7 @@ RcCore::ToolBar RcDocument::toolBar(const QString &id) const
  */
 RcCore::Widget RcDocument::dialog(const QString &id, int flags, double scaleX, double scaleY) const
 {
-    LOG("RcDocument::dialog", id, flags, scaleX, scaleY);
+    LOG(id, flags, scaleX, scaleY);
 
     SET_DEFAULT_VALUE(RcDialogFlags, static_cast<ConversionFlags>(flags));
     SET_DEFAULT_VALUE(RcDialogScaleX, scaleX);
@@ -235,7 +235,7 @@ RcCore::Widget RcDocument::dialog(const QString &id, int flags, double scaleX, d
  */
 RcCore::Menu RcDocument::menu(const QString &id) const
 {
-    LOG("RcDocument::menu", id);
+    LOG(id);
 
     if (isDataValid()) {
         if (auto menu = data().menu(id))
@@ -250,7 +250,7 @@ RcCore::Menu RcDocument::menu(const QString &id) const
  */
 RcCore::Ribbon RcDocument::ribbon(const QString &id) const
 {
-    LOG("RcDocument::ribbon", id);
+    LOG(id);
 
     if (isDataValid()) {
         if (auto ribbon = data().ribbon(id)) {
@@ -263,7 +263,7 @@ RcCore::Ribbon RcDocument::ribbon(const QString &id) const
 
 QStringList RcDocument::dialogIds() const
 {
-    LOG("RcDocument::dialogIds");
+    LOG();
     if (isDataValid()) {
         const auto &dialogs = data().dialogs;
         QStringList result;
@@ -279,7 +279,7 @@ QStringList RcDocument::dialogIds() const
 
 QStringList RcDocument::menuIds() const
 {
-    LOG("RcDocument::menuIds");
+    LOG();
     if (isDataValid()) {
         const auto &menus = data().menus;
         QStringList result;
@@ -295,7 +295,7 @@ QStringList RcDocument::menuIds() const
 
 QStringList RcDocument::acceleratorIds() const
 {
-    LOG("RcDocument::acceleratorIds");
+    LOG();
     if (isDataValid()) {
         const auto &accelerators = data().acceleratorTables;
         QStringList result;
@@ -311,7 +311,7 @@ QStringList RcDocument::acceleratorIds() const
 
 QStringList RcDocument::toolbarIds() const
 {
-    LOG("RcDocument::toolbarIds");
+    LOG();
     if (isDataValid()) {
         const auto &toolbars = data().toolBars;
         QStringList result;
@@ -327,7 +327,7 @@ QStringList RcDocument::toolbarIds() const
 
 QStringList RcDocument::stringIds() const
 {
-    LOG("RcDocument::stringIds");
+    LOG();
     if (isDataValid())
         return data().strings.keys();
     return {};
@@ -335,7 +335,7 @@ QStringList RcDocument::stringIds() const
 
 QStringList RcDocument::ribbonIds() const
 {
-    LOG("RcDocument::ribbonIds");
+    LOG();
     if (isDataValid()) {
         const auto &ribbons = data().ribbons;
         QStringList result;
@@ -355,7 +355,7 @@ QStringList RcDocument::ribbonIds() const
  */
 QList<RcCore::String> RcDocument::stringsForLanguage(const QString &language) const
 {
-    LOG("RcDocument::stringsForLanguage", language);
+    LOG(language);
     if (m_rcFile.isValid && m_rcFile.data.contains(language)) {
         const RcCore::Data data = const_cast<RcCore::RcFile *>(&m_rcFile)->data[language];
         const auto &strings = data.strings;
@@ -371,14 +371,14 @@ QList<RcCore::String> RcDocument::stringsForLanguage(const QString &language) co
  */
 QString RcDocument::stringForLanguage(const QString &language, const QString &id) const
 {
-    LOG("RcDocument::stringForLanguage", language, id);
+    LOG(language, id);
 
     if (m_rcFile.isValid && m_rcFile.data.contains(language)) {
         const RcCore::Data data = const_cast<RcCore::RcFile *>(&m_rcFile)->data[language];
         const auto &strings = data.strings;
         return strings.value(id).text;
     } else {
-        spdlog::warn("RcDocument::stringForLanguage: language {} does not exist in the rc file.", language);
+        spdlog::warn("{}: language {} does not exist in the rc file.", FUNCTION_NAME, language);
         return {};
     }
 }
@@ -398,7 +398,7 @@ QList<RcCore::String> RcDocument::strings() const
  */
 QString RcDocument::string(const QString &id) const
 {
-    LOG("RcDocument::string", id);
+    LOG(id);
 
     if (isDataValid())
         return data().strings.value(id).text;
@@ -422,13 +422,12 @@ QString extractStringForDialog(const RcCore::Data::Dialog *dialog, const QString
     if (dialog) {
         const auto control = findControlWithId(dialog, id);
         if (!control) {
-            spdlog::warn("RcDocument::stringForDialogAndLanguage: control from id {} does not exist in the rc file.",
-                         id);
+            spdlog::warn("{}: control from id {} does not exist in the rc file.", FUNCTION_NAME, id);
             return {};
         }
         return control.value().text;
     } else {
-        spdlog::warn("RcDocument::stringForDialogAndLanguage: id {} does not exist in the rc file.", id);
+        spdlog::warn("{}: id {} does not exist in the rc file.", FUNCTION_NAME, id);
         return {};
     }
 }
@@ -440,14 +439,14 @@ QString extractStringForDialog(const RcCore::Data::Dialog *dialog, const QString
 QString RcDocument::stringForDialogAndLanguage(const QString &language, const QString &dialogId,
                                                const QString &id) const
 {
-    LOG("RcDocument::stringForDialogAndLanguage", language, dialogId, id);
+    LOG(language, dialogId, id);
 
     if (m_rcFile.isValid && m_rcFile.data.contains(language)) {
         const RcCore::Data data = const_cast<RcCore::RcFile *>(&m_rcFile)->data[language];
         const auto dialog = data.dialog(dialogId);
         return extractStringForDialog(dialog, id);
     } else {
-        spdlog::warn("RcDocument::stringForDialogAndLanguage: language {} does not exist in the rc file.", language);
+        spdlog::warn("{}: language {} does not exist in the rc file.", FUNCTION_NAME, language);
         return {};
     }
 }
@@ -458,7 +457,7 @@ QString RcDocument::stringForDialogAndLanguage(const QString &language, const QS
  */
 QString RcDocument::stringForDialog(const QString &dialogId, const QString &id) const
 {
-    LOG("RcDocument::stringForDialog", dialogId, id);
+    LOG(dialogId, id);
     if (isDataValid()) {
         const auto dialog = data().dialog(dialogId);
         return extractStringForDialog(dialog, id);
@@ -474,16 +473,16 @@ const RcCore::Data &RcDocument::data() const
 
 QString RcDocument::language() const
 {
-    LOG("RcDocument::language");
+    LOG();
     LOG_RETURN("language", m_language);
 }
 
 void RcDocument::setLanguage(const QString &language)
 {
-    LOG("RcDocument::setLanguage", language);
+    LOG(language);
 
     if (!m_rcFile.data.contains(language)) {
-        spdlog::warn("RcDocument::setLanguage: language {} does not exist in the rc file.", language);
+        spdlog::warn("{}: language {} does not exist in the rc file.", FUNCTION_NAME, language);
         return;
     }
 
@@ -499,7 +498,7 @@ void RcDocument::setLanguage(const QString &language)
 
 QStringList RcDocument::languages() const
 {
-    LOG("RcDocument::languages");
+    LOG();
 
     QStringList langs;
     if (m_rcFile.isValid) {
@@ -535,7 +534,7 @@ QList<RcCore::Menu> RcDocument::menus() const
  */
 void RcDocument::convertAssets(int flags)
 {
-    LOG("RcDocument::convertAssets", flags);
+    LOG(flags);
 
     SET_DEFAULT_VALUE(RcAssetFlags, static_cast<ConversionFlags>(flags));
     if (isDataValid()) {
@@ -558,7 +557,7 @@ void RcDocument::convertAssets(int flags)
  */
 void RcDocument::convertActions(int flags)
 {
-    LOG("RcDocument::convertActions", flags);
+    LOG(flags);
 
     SET_DEFAULT_VALUE(RcAssetFlags, static_cast<ConversionFlags>(flags));
     if (isDataValid()) {
@@ -584,7 +583,7 @@ void RcDocument::convertActions(int flags)
  */
 bool RcDocument::writeAssetsToImage(int flags)
 {
-    LOG("RcDocument::writeAssetsToImage", flags);
+    LOG(flags);
 
     SET_DEFAULT_VALUE(RcAssetColors, static_cast<ConversionFlags>(flags));
     if (m_cacheAssets.isEmpty())
@@ -602,7 +601,7 @@ bool RcDocument::writeAssetsToImage(int flags)
  */
 bool RcDocument::writeAssetsToQrc(const QString &fileName)
 {
-    LOG("RcDocument::writeAssetsToQrc", fileName);
+    LOG(fileName);
 
     if (m_cacheAssets.isEmpty())
         convertAssets();
@@ -622,7 +621,7 @@ bool RcDocument::writeAssetsToQrc(const QString &fileName)
  */
 bool RcDocument::writeDialogToUi(const RcCore::Widget &dialog, const QString &fileName)
 {
-    LOG("RcDocument::writeDialogToUi", dialog.id, fileName);
+    LOG(dialog.id, fileName);
 
     QFile file(fileName);
     if (file.open(QIODevice::WriteOnly)) {
@@ -639,7 +638,7 @@ bool RcDocument::writeDialogToUi(const RcCore::Widget &dialog, const QString &fi
  */
 void RcDocument::previewDialog(const RcCore::Widget &dialog) const
 {
-    LOG("RcDocument::previewDialog", dialog.id);
+    LOG(dialog.id);
 
     QUiLoader loader;
 
@@ -662,7 +661,7 @@ void RcDocument::previewDialog(const RcCore::Widget &dialog) const
  */
 void RcDocument::mergeAllLanguages(const QString &language)
 {
-    LOG("RcDocument::mergeAllLanguages", language);
+    LOG(language);
 
     m_rcFile.mergeLanguages(m_rcFile.data.keys(), language);
     {
@@ -684,7 +683,7 @@ void RcDocument::mergeAllLanguages(const QString &language)
  */
 void RcDocument::mergeLanguages()
 {
-    LOG("RcDocument::mergeLanguages");
+    LOG();
 
     const auto languageMap = Settings::instance()->value<std::map<std::string, std::string>>(Settings::RcLanguageMap);
 
@@ -723,7 +722,7 @@ void RcDocument::mergeLanguages()
  */
 QString RcDocument::convertLanguageToCode(const QString &language)
 {
-    LOG("RcDocument::convertLanguageToCode", language);
+    LOG(language);
     if (language == DefaultLanguage) {
         return {};
     }

--- a/src/core/scriptdialogitem.cpp
+++ b/src/core/scriptdialogitem.cpp
@@ -173,7 +173,7 @@ void ScriptDialogItem::initialize(nlohmann::json &&jsonData)
         } else if (it.value().is_number_float()) {
             value = it.value().get<double>();
         } else {
-            spdlog::error("Unsupported data type for key '{}'", it.key());
+            spdlog::error("{}: Unsupported data type for key '{}'", FUNCTION_NAME, it.key());
             value = QString::fromStdString(it.value().dump());
         }
 
@@ -294,7 +294,7 @@ void ScriptDialogItem::continueScript()
 
 void ScriptDialogItem::abortScript()
 {
-    spdlog::info("Script aborted.");
+    spdlog::info("{}: Script aborted.", FUNCTION_NAME);
     finishScript();
 }
 
@@ -313,7 +313,7 @@ void ScriptDialogItem::runNextStep()
     const auto done = result.property("done").toBool();
     m_nextStepTitle = result.property("value").toString();
 
-    spdlog::info("{} done.", m_currentStepTitle);
+    spdlog::info("{}: {} done.", FUNCTION_NAME, m_currentStepTitle);
 
     if (done) {
         finishScript();
@@ -535,7 +535,7 @@ void ScriptDialogItem::setUiFile(const QString &fileName)
         setWindowTitle(internalWidget->windowTitle());
         createProperties(internalWidget);
     } else {
-        spdlog::error("Can't open {}", fileName);
+        spdlog::error("{}: Can't open {}", FUNCTION_NAME, fileName);
     }
 }
 
@@ -677,10 +677,10 @@ void ScriptDialogItem::changeValue(const QString &key, const QVariant &value)
     }
 
     if (!widget) {
-        spdlog::warn("No widget found for the key '{}'.", key.toStdString());
+        spdlog::warn("{}: No widget found for the key '{}'.", FUNCTION_NAME, key.toStdString());
     } else {
-        spdlog::warn("Unsupported widget type '{}' for the key '{}'.", widget->metaObject()->className(),
-                     key.toStdString());
+        spdlog::warn("{}: Unsupported widget type '{}' for the key '{}'.", FUNCTION_NAME,
+                     widget->metaObject()->className(), key.toStdString());
     }
 }
 

--- a/src/core/scriptdialogitem_p.cpp
+++ b/src/core/scriptdialogitem_p.cpp
@@ -73,7 +73,7 @@ int DynamicObject::qt_metacall(QMetaObject::Call call, int id, void **argv)
         if (m_dataChangedCallback)
             m_dataChangedCallback(property.name, property.variant);
     } else {
-        spdlog::warn("DynamicObject::qt_metacall: id {} not handled.", id);
+        spdlog::warn("{}: id {} not handled.", FUNCTION_NAME, id);
     }
 
     return -1;

--- a/src/core/scriptmanager.cpp
+++ b/src/core/scriptmanager.cpp
@@ -208,7 +208,7 @@ void ScriptManager::doRunScript(const QString &fileName, nlohmann::json &&data, 
             spdlog::error("{}({}): {}", error.url().toLocalFile(), error.line(), error.description());
     } else {
         if (m_result.isValid())
-            spdlog::info("Script result is {}", m_result.toString());
+            spdlog::info("{}: Script result is {}", FUNCTION_NAME, m_result.toString());
     }
 }
 

--- a/src/core/scriptmodel.cpp
+++ b/src/core/scriptmodel.cpp
@@ -71,7 +71,7 @@ QVariant ScriptModel::columnHeaderDisplayData(int column) const
     case DescriptionColumn:
         return tr("Description");
     default:
-        spdlog::error("SuggestedScripts::columnHeaderDisplayData: column out of range: {}", column);
+        spdlog::error("{}: column out of range: {}", FUNCTION_NAME, column);
         return {};
     }
 }
@@ -95,7 +95,7 @@ QVariant ScriptModel::data(const QModelIndex &index, int role) const
 
     const auto &scripts = scriptList();
     if (row < 0 || static_cast<size_t>(row) >= scripts.size()) {
-        spdlog::error("SuggestedScripts::data: row out of range: {}", row);
+        spdlog::error("{}: row out of range: {}", FUNCTION_NAME, row);
         return {};
     }
 
@@ -120,7 +120,7 @@ QVariant ScriptModel::displayData(const ScriptManager::Script &script, int colum
     case DescriptionColumn:
         return script.description;
     default:
-        spdlog::error("SuggestedScripts::displayData: column out of range: {}", column);
+        spdlog::error("{}: column out of range: {}", FUNCTION_NAME, column);
         return {};
     }
 }

--- a/src/core/scriptrunner.cpp
+++ b/src/core/scriptrunner.cpp
@@ -196,7 +196,7 @@ QVariant ScriptRunner::runScript(const QString &fileName, nlohmann::json &&data,
         }
         // engine is deleted in runJavascript or runQml
     } else {
-        spdlog::error("File {} doesn't exist", fileName);
+        spdlog::error("{}: File {} doesn't exist", FUNCTION_NAME, fileName);
         return QVariant(ErrorCode);
     }
 

--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -122,7 +122,7 @@ void Settings::triggerLog(const Utils::LoadJsonStatus &loadJsonStatus, const QSt
  */
 bool Settings::hasValue(const QString &path) const
 {
-    LOG("Settings::hasValue", path);
+    LOG(path);
     return Utils::hasJsonValue(m_settings, path);
 }
 
@@ -133,9 +133,9 @@ bool Settings::hasValue(const QString &path) const
 QVariant Settings::value(const QString &path, const QVariant &defaultValue) const
 {
     if (defaultValue.isValid())
-        LOG("Settings::value", path, defaultValue);
+        LOG(path, defaultValue);
     else
-        LOG("Settings::value", path);
+        LOG(path);
 
     // Special cases
     if (path == Settings::RcAssetColors || path == Settings::RcAssetFlags || path == Settings::RcDialogFlags) {
@@ -148,10 +148,10 @@ QVariant Settings::value(const QString &path, const QVariant &defaultValue) cons
     case Utils::JsonValueStatus::Success:
         return valueStatus.value;
     case Utils::JsonValueStatus::ValueUnknown:
-        spdlog::info("Settings::value {} - accessing non-existing value", path);
+        spdlog::info("{}: {} - accessing non-existing value", FUNCTION_NAME, path);
         break;
     case Utils::JsonValueStatus::ConversionUnknown:
-        spdlog::error("Settings::value {} - cannot convert", path);
+        spdlog::error("{}: {} - cannot convert", FUNCTION_NAME, path);
         break;
     }
     return defaultValue;
@@ -165,7 +165,7 @@ bool Settings::setValue(const QString &path, const QJSValue &value)
 {
     const auto var = value.toVariant();
 
-    LOG("Settings::setValue", path, var);
+    LOG(path, value);
 
     // Handle both settings and project settings
     Utils::SetJsonValueStatus status = Utils::setJsonValue(m_settings, path, var);
@@ -181,10 +181,10 @@ bool Settings::setValue(const QString &path, const QJSValue &value)
         return true;
     }
     case Utils::SetJsonValueStatus::NullValue:
-        spdlog::error("Settings::setValue {} in {} - value is null", value.toString(), path);
+        spdlog::error("{}: {} in {} - value is null", FUNCTION_NAME, value.toString(), path);
         break;
     case Utils::SetJsonValueStatus::ValueTypeNotHandled:
-        spdlog::error("Settings::setValue {} in {} - value type not handled", value.toString(), path);
+        spdlog::error("{}: {} in {} - value type not handled", FUNCTION_NAME, value.toString(), path);
         break;
     }
     return false;
@@ -237,7 +237,7 @@ void Settings::saveSettings()
 
     QFile file(filePath);
     if (!file.open(QIODevice::WriteOnly | QIODevice::Truncate)) {
-        spdlog::error("Settings::saveSettings {}", filePath);
+        spdlog::error("{}: {}", FUNCTION_NAME, filePath);
         return;
     }
 

--- a/src/core/symbol.cpp
+++ b/src/core/symbol.cpp
@@ -138,12 +138,12 @@ bool Symbol::isClass() const
 
 ClassSymbol *Symbol::toClass()
 {
-    LOG("Symbol::toClass");
+    LOG();
 
     auto clazz = qobject_cast<ClassSymbol *>(this);
 
     if (!clazz)
-        spdlog::warn("Symbol::toClass - {} should be a `Class`.", m_name);
+        spdlog::warn("{}: {} should be a `Class`.", FUNCTION_NAME, m_name);
 
     return clazz;
 }
@@ -164,7 +164,7 @@ FunctionSymbol *Symbol::toFunction()
     auto function = qobject_cast<FunctionSymbol *>(this);
 
     if (!function)
-        spdlog::warn("Symbol::toFunction - {} should be either a method or a function.", m_name);
+        spdlog::warn("{}: {} should be either a method or a function.", FUNCTION_NAME, m_name);
 
     return function;
 }
@@ -196,7 +196,7 @@ Core::RangeMark Symbol::selectionRange() const
 
 RangeMarkList Symbol::references() const
 {
-    LOG("Symbol::references");
+    LOG();
 
     if (const auto codedocument = document()) {
         auto references = codedocument->references(selectionRange().start());

--- a/src/core/textdocument.cpp
+++ b/src/core/textdocument.cpp
@@ -243,7 +243,7 @@ bool TextDocument::doSave(const QString &fileName)
     QFile file(fileName);
     if (!file.open(QIODevice::WriteOnly | QIODevice::Truncate)) {
         setErrorString(file.errorString());
-        spdlog::error("Can't save file {}: {}", fileName, errorString());
+        spdlog::error("{} - Can't save file {}: {}", FUNCTION_NAME, fileName, errorString());
         return false;
     }
 
@@ -266,7 +266,7 @@ bool TextDocument::doLoad(const QString &fileName)
     QFile file(fileName);
     if (!file.open(QIODevice::ReadOnly)) {
         setErrorString(file.errorString());
-        spdlog::warn("Can't load file {}: {}", fileName, errorString());
+        spdlog::warn("{} - Can't load file {}: {}", FUNCTION_NAME, fileName, errorString());
         return false;
     }
 
@@ -306,45 +306,45 @@ void TextDocument::detectFormat(const QByteArray &data)
 
 int TextDocument::column() const
 {
-    LOG("TextDocument::column");
+    LOG();
     const QTextCursor cursor = m_document->textCursor();
     LOG_RETURN("column", cursor.positionInBlock() + 1);
 }
 
 int TextDocument::line() const
 {
-    LOG("TextDocument::line");
+    LOG();
     const QTextCursor cursor = m_document->textCursor();
     LOG_RETURN("line", cursor.blockNumber() + 1);
 }
 
 int TextDocument::lineCount() const
 {
-    LOG("TextDocument::lineCount");
+    LOG();
     return m_document->document()->lineCount();
 }
 
 int TextDocument::position() const
 {
-    LOG("TextDocument::position");
+    LOG();
     LOG_RETURN("pos", m_document->textCursor().position());
 }
 
 int TextDocument::selectionStart() const
 {
-    LOG("TextDocument::selectionStart");
+    LOG();
     LOG_RETURN("pos", m_document->textCursor().selectionStart());
 }
 
 int TextDocument::selectionEnd() const
 {
-    LOG("TextDocument::selectionEnd");
+    LOG();
     LOG_RETURN("pos", m_document->textCursor().selectionEnd());
 }
 
 void TextDocument::setPosition(int newPosition)
 {
-    LOG("TextDocument::position", LOG_ARG("pos", newPosition));
+    LOG(LOG_ARG("pos", newPosition));
 
     if (position() == newPosition)
         return;
@@ -388,7 +388,7 @@ int TextDocument::position(QTextCursor::MoveOperation operation, int pos) const
  */
 int TextDocument::lineAtPosition(int position)
 {
-    LOG("TextDocument::lineAtPosition", LOG_ARG("position", position));
+    LOG(LOG_ARG("position", position));
     int line = -1;
     int col = -1;
     convertPosition(position, &line, &col);
@@ -401,7 +401,7 @@ int TextDocument::lineAtPosition(int position)
  */
 int TextDocument::columnAtPosition(int position)
 {
-    LOG("TextDocument::columnAtPosition", LOG_ARG("position", position));
+    LOG(LOG_ARG("position", position));
     int line = -1;
     int col = -1;
     convertPosition(position, &line, &col);
@@ -414,7 +414,7 @@ int TextDocument::columnAtPosition(int position)
  */
 int TextDocument::positionAt(int line, int column)
 {
-    LOG("TextDocument::positionAt", LOG_ARG("line", line), LOG_ARG("column", column));
+    LOG(LOG_ARG("line", line), LOG_ARG("column", column));
     const QTextBlock block = m_document->document()->findBlockByLineNumber(line - 1);
     if (!block.isValid()) {
         return -1;
@@ -425,20 +425,20 @@ int TextDocument::positionAt(int line, int column)
 
 QString TextDocument::text() const
 {
-    LOG("TextDocument::text");
+    LOG();
     LOG_RETURN("text", m_document->toPlainText());
 }
 
 void TextDocument::setText(const QString &newText)
 {
-    LOG("TextDocument::text", LOG_ARG("text", newText));
+    LOG(LOG_ARG("text", newText));
 
     m_document->setPlainText(newText);
 }
 
 QString TextDocument::currentLine() const
 {
-    LOG("TextDocument::currentLine");
+    LOG();
     QTextCursor cursor = m_document->textCursor();
     cursor.movePosition(QTextCursor::StartOfLine);
     cursor.movePosition(QTextCursor::EndOfLine, QTextCursor::KeepAnchor);
@@ -447,7 +447,7 @@ QString TextDocument::currentLine() const
 
 QString TextDocument::currentWord() const
 {
-    LOG("TextDocument::currentWord");
+    LOG();
     QTextCursor cursor = m_document->textCursor();
     cursor.movePosition(QTextCursor::StartOfWord);
     cursor.movePosition(QTextCursor::EndOfWord, QTextCursor::KeepAnchor);
@@ -456,7 +456,7 @@ QString TextDocument::currentWord() const
 
 QString TextDocument::selectedText() const
 {
-    LOG("TextDocument::selectedText");
+    LOG();
     // Replace \u2029 with \n
     const QString text = m_document->textCursor().selectedText().replace(QChar(8233), "\n");
     LOG_RETURN("text", text);
@@ -494,7 +494,7 @@ QString TextDocument::tab() const
  */
 void TextDocument::undo(int count)
 {
-    LOG_AND_MERGE("TextDocument::undo", count);
+    LOG_AND_MERGE(count);
     while (count != 0) {
         m_document->undo();
         --count;
@@ -507,7 +507,7 @@ void TextDocument::undo(int count)
  */
 void TextDocument::redo(int count)
 {
-    LOG_AND_MERGE("TextDocument::redo", count);
+    LOG_AND_MERGE(count);
     while (count != 0) {
         m_document->redo();
         --count;
@@ -529,7 +529,7 @@ void TextDocument::movePosition(QTextCursor::MoveOperation operation, QTextCurso
  */
 void TextDocument::gotoLine(int line, int column)
 {
-    LOG("TextDocument::gotoLine", LOG_ARG("line", line), LOG_ARG("column", column));
+    LOG(LOG_ARG("line", line), LOG_ARG("column", column));
 
     gotoLineInTextEdit(m_document, line, column);
 }
@@ -555,7 +555,7 @@ void gotoLineInTextEdit(QPlainTextEdit *textEdit, int line, int column)
  */
 void TextDocument::gotoStartOfLine()
 {
-    LOG("TextDocument::gotoStartOfLine");
+    LOG();
     movePosition(QTextCursor::StartOfLine);
 }
 
@@ -565,7 +565,7 @@ void TextDocument::gotoStartOfLine()
  */
 void TextDocument::gotoEndOfLine()
 {
-    LOG("TextDocument::gotoEndOfLine");
+    LOG();
     movePosition(QTextCursor::EndOfLine);
 }
 
@@ -575,7 +575,7 @@ void TextDocument::gotoEndOfLine()
  */
 void TextDocument::gotoStartOfWord()
 {
-    LOG("TextDocument::gotoStartOfWord");
+    LOG();
     movePosition(QTextCursor::StartOfWord);
 }
 
@@ -585,7 +585,7 @@ void TextDocument::gotoStartOfWord()
  */
 void TextDocument::gotoEndOfWord()
 {
-    LOG("TextDocument::gotoEndOfWord");
+    LOG();
     movePosition(QTextCursor::EndOfWord);
 }
 
@@ -595,7 +595,7 @@ void TextDocument::gotoEndOfWord()
  */
 void TextDocument::gotoNextLine(int count)
 {
-    LOG_AND_MERGE("TextDocument::gotoNextLine", count);
+    LOG_AND_MERGE(count);
     movePosition(QTextCursor::Down, QTextCursor::MoveAnchor, count);
 }
 
@@ -605,7 +605,7 @@ void TextDocument::gotoNextLine(int count)
  */
 void TextDocument::gotoPreviousLine(int count)
 {
-    LOG_AND_MERGE("TextDocument::gotoPreviousLine", count);
+    LOG_AND_MERGE(count);
     movePosition(QTextCursor::Up, QTextCursor::MoveAnchor, count);
 }
 
@@ -615,7 +615,7 @@ void TextDocument::gotoPreviousLine(int count)
  */
 void TextDocument::gotoPreviousChar(int count)
 {
-    LOG_AND_MERGE("TextDocument::gotoPreviousChar", count);
+    LOG_AND_MERGE(count);
     movePosition(QTextCursor::PreviousCharacter, QTextCursor::MoveAnchor, count);
 }
 
@@ -625,7 +625,7 @@ void TextDocument::gotoPreviousChar(int count)
  */
 void TextDocument::gotoNextChar(int count)
 {
-    LOG_AND_MERGE("TextDocument::gotoNextChar", count);
+    LOG_AND_MERGE(count);
     movePosition(QTextCursor::NextCharacter, QTextCursor::MoveAnchor, count);
 }
 
@@ -635,7 +635,7 @@ void TextDocument::gotoNextChar(int count)
  */
 void TextDocument::gotoPreviousWord(int count)
 {
-    LOG_AND_MERGE("TextDocument::gotoPreviousWord", count);
+    LOG_AND_MERGE(count);
     movePosition(QTextCursor::PreviousWord, QTextCursor::MoveAnchor, count);
 }
 
@@ -645,7 +645,7 @@ void TextDocument::gotoPreviousWord(int count)
  */
 void TextDocument::gotoNextWord(int count)
 {
-    LOG_AND_MERGE("TextDocument::gotoNextWord", count);
+    LOG_AND_MERGE(count);
     movePosition(QTextCursor::NextWord, QTextCursor::MoveAnchor, count);
 }
 
@@ -655,7 +655,7 @@ void TextDocument::gotoNextWord(int count)
  */
 void TextDocument::gotoStartOfDocument()
 {
-    LOG("TextDocument::gotoStartOfDocument");
+    LOG();
     movePosition(QTextCursor::Start);
 }
 
@@ -665,7 +665,7 @@ void TextDocument::gotoStartOfDocument()
  */
 void TextDocument::gotoEndOfDocument()
 {
-    LOG("TextDocument::gotoEndOfDocument");
+    LOG();
     movePosition(QTextCursor::End);
 }
 
@@ -675,7 +675,7 @@ void TextDocument::gotoEndOfDocument()
  */
 void TextDocument::unselect()
 {
-    LOG("TextDocument::unselect");
+    LOG();
     QTextCursor cursor = m_document->textCursor();
     cursor.clearSelection();
     m_document->setTextCursor(cursor);
@@ -687,7 +687,7 @@ void TextDocument::unselect()
  */
 bool TextDocument::hasSelection()
 {
-    LOG("TextDocument::hasSelection");
+    LOG();
     return m_document->textCursor().hasSelection();
 }
 
@@ -697,7 +697,7 @@ bool TextDocument::hasSelection()
  */
 void TextDocument::selectAll()
 {
-    LOG("TextDocument::selectAll");
+    LOG();
     m_document->selectAll();
 }
 
@@ -707,7 +707,7 @@ void TextDocument::selectAll()
  */
 void TextDocument::selectTo(int pos)
 {
-    LOG("TextDocument::selectTo", LOG_ARG("pos", pos));
+    LOG(LOG_ARG("pos", pos));
     QTextCursor cursor = m_document->textCursor();
     cursor.setPosition(pos, QTextCursor::KeepAnchor);
     m_document->setTextCursor(cursor);
@@ -719,7 +719,7 @@ void TextDocument::selectTo(int pos)
  */
 void TextDocument::selectStartOfLine()
 {
-    LOG("TextDocument::selectStartOfLine");
+    LOG();
     movePosition(QTextCursor::StartOfLine, QTextCursor::KeepAnchor);
 }
 
@@ -729,7 +729,7 @@ void TextDocument::selectStartOfLine()
  */
 void TextDocument::selectEndOfLine()
 {
-    LOG("TextDocument::selectEndOfLine");
+    LOG();
     movePosition(QTextCursor::EndOfLine, QTextCursor::KeepAnchor);
 }
 
@@ -739,7 +739,7 @@ void TextDocument::selectEndOfLine()
  */
 void TextDocument::selectStartOfWord()
 {
-    LOG("TextDocument::selectStartOfWord");
+    LOG();
     movePosition(QTextCursor::StartOfWord, QTextCursor::KeepAnchor);
 }
 
@@ -749,7 +749,7 @@ void TextDocument::selectStartOfWord()
  */
 void TextDocument::selectEndOfWord()
 {
-    LOG("TextDocument::selectEndOfWord");
+    LOG();
     movePosition(QTextCursor::EndOfWord, QTextCursor::KeepAnchor);
 }
 
@@ -759,7 +759,7 @@ void TextDocument::selectEndOfWord()
  */
 void TextDocument::selectNextLine(int count)
 {
-    LOG_AND_MERGE("TextDocument::selectNextLine", count);
+    LOG_AND_MERGE(count);
     movePosition(QTextCursor::Down, QTextCursor::KeepAnchor, count);
 }
 
@@ -769,7 +769,7 @@ void TextDocument::selectNextLine(int count)
  */
 void TextDocument::selectPreviousLine(int count)
 {
-    LOG_AND_MERGE("TextDocument::selectPreviousLine", count);
+    LOG_AND_MERGE(count);
     movePosition(QTextCursor::Up, QTextCursor::KeepAnchor, count);
 }
 
@@ -779,7 +779,7 @@ void TextDocument::selectPreviousLine(int count)
  */
 void TextDocument::selectPreviousChar(int count)
 {
-    LOG_AND_MERGE("TextDocument::selectPreviousChar", count);
+    LOG_AND_MERGE(count);
     movePosition(QTextCursor::PreviousCharacter, QTextCursor::KeepAnchor, count);
 }
 
@@ -789,7 +789,7 @@ void TextDocument::selectPreviousChar(int count)
  */
 void TextDocument::selectNextChar(int count)
 {
-    LOG_AND_MERGE("TextDocument::selectNextChar", count);
+    LOG_AND_MERGE(count);
     movePosition(QTextCursor::NextCharacter, QTextCursor::KeepAnchor, count);
 }
 
@@ -799,7 +799,7 @@ void TextDocument::selectNextChar(int count)
  */
 void TextDocument::selectPreviousWord(int count)
 {
-    LOG_AND_MERGE("TextDocument::selectPreviousWord", count);
+    LOG_AND_MERGE(count);
     movePosition(QTextCursor::PreviousWord, QTextCursor::KeepAnchor, count);
 }
 
@@ -809,7 +809,7 @@ void TextDocument::selectPreviousWord(int count)
  */
 void TextDocument::selectNextWord(int count)
 {
-    LOG_AND_MERGE("TextDocument::selectNextWord", count);
+    LOG_AND_MERGE(count);
     movePosition(QTextCursor::NextWord, QTextCursor::KeepAnchor, count);
 }
 
@@ -819,7 +819,7 @@ void TextDocument::selectNextWord(int count)
  */
 void TextDocument::selectRegion(int from, int to)
 {
-    LOG("TextDocument::selectRegion", from, to);
+    LOG(from, to);
     QTextCursor cursor(m_document->document());
     cursor.setPosition(from, QTextCursor::MoveAnchor);
     cursor.setPosition(to, QTextCursor::KeepAnchor);
@@ -832,7 +832,7 @@ void TextDocument::selectRegion(int from, int to)
  */
 void TextDocument::selectRange(const RangeMark &range)
 {
-    LOG("TextDocument::selectRange", range);
+    LOG(range);
     selectRegion(range.start(), range.end());
 }
 
@@ -842,7 +842,7 @@ void TextDocument::selectRange(const RangeMark &range)
  */
 void TextDocument::copy()
 {
-    LOG("TextDocument::copy");
+    LOG();
     m_document->copy();
 }
 
@@ -852,7 +852,7 @@ void TextDocument::copy()
  */
 void TextDocument::paste()
 {
-    LOG("TextDocument::paste");
+    LOG();
     m_document->paste();
 }
 
@@ -862,7 +862,7 @@ void TextDocument::paste()
  */
 void TextDocument::cut()
 {
-    LOG("TextDocument::cut");
+    LOG();
     m_document->cut();
 }
 
@@ -872,7 +872,7 @@ void TextDocument::cut()
  */
 void TextDocument::remove(int length)
 {
-    LOG("TextDocument::remove", length);
+    LOG(length);
     QTextCursor cursor = m_document->textCursor();
     cursor.setPosition(cursor.position() + length, QTextCursor::KeepAnchor);
     cursor.removeSelectedText();
@@ -885,7 +885,7 @@ void TextDocument::remove(int length)
  */
 void TextDocument::insert(const QString &text)
 {
-    LOG_AND_MERGE("TextDocument::insert", LOG_ARG("text", text));
+    LOG_AND_MERGE(LOG_ARG("text", text));
     m_document->insertPlainText(text);
 }
 
@@ -896,9 +896,9 @@ void TextDocument::insert(const QString &text)
 void TextDocument::insertAtLine(const QString &text, int line)
 {
     if (line == -1)
-        LOG("TextDocument::insertAtLine", LOG_ARG("text", text));
+        LOG(LOG_ARG("text", text));
     else
-        LOG("TextDocument::insertAtLine", LOG_ARG("text", text), LOG_ARG("line", line));
+        LOG(LOG_ARG("text", text), LOG_ARG("line", line));
 
     QTextCursor cursor = m_document->textCursor();
     if (line > 0) {
@@ -916,7 +916,7 @@ void TextDocument::insertAtLine(const QString &text, int line)
  */
 void TextDocument::insertAtPosition(const QString &text, int pos)
 {
-    LOG("TextDocument::insertAtPosition", text, pos);
+    LOG(text, pos);
     QTextCursor cursor = m_document->textCursor();
     cursor.setPosition(pos);
     cursor.beginEditBlock();
@@ -931,7 +931,7 @@ void TextDocument::insertAtPosition(const QString &text, int pos)
  */
 void TextDocument::replace(int length, const QString &text)
 {
-    LOG("TextDocument::replace", length, text);
+    LOG(length, text);
     QTextCursor cursor = m_document->textCursor();
     cursor.setPosition(cursor.position() + length, QTextCursor::KeepAnchor);
     cursor.insertText(text);
@@ -944,7 +944,7 @@ void TextDocument::replace(int length, const QString &text)
  */
 void TextDocument::replace(int from, int to, const QString &text)
 {
-    LOG("TextDocument::replace", from, to, text);
+    LOG(from, to, text);
     QTextCursor cursor(m_document->document());
     cursor.setPosition(from);
     cursor.setPosition(to, QTextCursor::KeepAnchor);
@@ -958,7 +958,7 @@ void TextDocument::replace(int from, int to, const QString &text)
  */
 void TextDocument::replace(const RangeMark &range, const QString &text)
 {
-    LOG("TextDocument::replace", range, text);
+    LOG(range, text);
     replace(range.start(), range.end(), text);
 }
 
@@ -969,9 +969,9 @@ void TextDocument::replace(const RangeMark &range, const QString &text)
 void TextDocument::deleteLine(int line)
 {
     if (line == -1)
-        LOG("TextDocument::deleteLine");
+        LOG();
     else
-        LOG("TextDocument::deleteLine", LOG_ARG("line", line));
+        LOG(LOG_ARG("line", line));
 
     QTextCursor cursor = m_document->textCursor();
     if (line > 0) {
@@ -992,7 +992,7 @@ void TextDocument::deleteLine(int line)
  */
 void TextDocument::deleteSelection()
 {
-    LOG("TextDocument::deleteSelection");
+    LOG();
     m_document->textCursor().removeSelectedText();
 }
 
@@ -1002,7 +1002,7 @@ void TextDocument::deleteSelection()
  */
 void TextDocument::deleteRegion(int from, int to)
 {
-    LOG("TextDocument::deleteRegion", from, to);
+    LOG(from, to);
     QTextCursor cursor(m_document->document());
     cursor.setPosition(from);
     cursor.setPosition(to, QTextCursor::KeepAnchor);
@@ -1016,7 +1016,7 @@ void TextDocument::deleteRegion(int from, int to)
  */
 void TextDocument::deleteRange(const RangeMark &range)
 {
-    LOG("TextDocument::deleteRange", range);
+    LOG(range);
     QTextCursor cursor(m_document->document());
     cursor.setPosition(range.start(), QTextCursor::MoveAnchor);
     cursor.setPosition(range.end(), QTextCursor::KeepAnchor);
@@ -1030,7 +1030,7 @@ void TextDocument::deleteRange(const RangeMark &range)
  */
 void TextDocument::deleteEndOfLine()
 {
-    LOG("TextDocument::deleteEndOfLine");
+    LOG();
     QTextCursor cursor = m_document->textCursor();
     cursor.movePosition(QTextCursor::EndOfLine, QTextCursor::KeepAnchor);
     cursor.removeSelectedText();
@@ -1043,7 +1043,7 @@ void TextDocument::deleteEndOfLine()
  */
 void TextDocument::deleteStartOfLine()
 {
-    LOG("TextDocument::deleteStartOfLine");
+    LOG();
     QTextCursor cursor = m_document->textCursor();
     cursor.movePosition(QTextCursor::StartOfLine, QTextCursor::KeepAnchor);
     cursor.removeSelectedText();
@@ -1056,7 +1056,7 @@ void TextDocument::deleteStartOfLine()
  */
 void TextDocument::deleteEndOfWord()
 {
-    LOG("TextDocument::deleteEndOfWord");
+    LOG();
     QTextCursor cursor = m_document->textCursor();
     if (!cursor.hasSelection())
         cursor.movePosition(QTextCursor::NextWord, QTextCursor::KeepAnchor);
@@ -1070,7 +1070,7 @@ void TextDocument::deleteEndOfWord()
  */
 void TextDocument::deleteStartOfWord()
 {
-    LOG("TextDocument::deleteStartOfWord");
+    LOG();
     QTextCursor cursor = m_document->textCursor();
     if (!cursor.hasSelection())
         cursor.movePosition(QTextCursor::PreviousWord, QTextCursor::KeepAnchor);
@@ -1084,7 +1084,7 @@ void TextDocument::deleteStartOfWord()
  */
 void TextDocument::deletePreviousCharacter(int count)
 {
-    LOG_AND_MERGE("TextDocument::deletePreviousCharacter", count);
+    LOG_AND_MERGE(count);
     QTextCursor cursor = m_document->textCursor();
     cursor.movePosition(QTextCursor::PreviousCharacter, QTextCursor::KeepAnchor, count);
     cursor.removeSelectedText();
@@ -1097,7 +1097,7 @@ void TextDocument::deletePreviousCharacter(int count)
  */
 void TextDocument::deleteNextCharacter(int count)
 {
-    LOG_AND_MERGE("TextDocument::deleteNextCharacter", count);
+    LOG_AND_MERGE(count);
     QTextCursor cursor = m_document->textCursor();
     cursor.movePosition(QTextCursor::NextCharacter, QTextCursor::KeepAnchor, count);
     cursor.removeSelectedText();
@@ -1112,7 +1112,7 @@ void TextDocument::deleteNextCharacter(int count)
  */
 Mark TextDocument::createMark(int pos)
 {
-    LOG("TextDocument::createMark", LOG_ARG("pos", pos));
+    LOG(LOG_ARG("pos", pos));
     if (pos < 0)
         pos = position();
     LOG_RETURN("mark", Mark(this, pos));
@@ -1124,9 +1124,9 @@ Mark TextDocument::createMark(int pos)
  */
 void TextDocument::gotoMark(const Mark &mark)
 {
-    LOG("TextDocument::gotoMark", LOG_ARG("mark", mark));
+    LOG(LOG_ARG("mark", mark));
     if (mark.document() != this) {
-        spdlog::error("Can't use a mark from another editor.");
+        spdlog::error("{}: Can't use a mark from another editor.", FUNCTION_NAME);
         return;
     }
 
@@ -1141,9 +1141,9 @@ void TextDocument::gotoMark(const Mark &mark)
  */
 void TextDocument::selectToMark(const Mark &mark)
 {
-    LOG("TextDocument::selectToMark", LOG_ARG("mark", mark));
+    LOG(LOG_ARG("mark", mark));
     if (mark.document() != this) {
-        spdlog::error("Can't use a mark from another editor.");
+        spdlog::error("{}: Can't use a mark from another editor.", FUNCTION_NAME);
         return;
     }
 
@@ -1160,7 +1160,7 @@ void TextDocument::selectToMark(const Mark &mark)
  */
 Core::RangeMark TextDocument::createRangeMark(int from, int to)
 {
-    LOG("TextDocument::createRangeMark", LOG_ARG("start", from), LOG_ARG("end", to));
+    LOG(LOG_ARG("start", from), LOG_ARG("end", to));
     LOG_RETURN("rangeMark", Core::RangeMark(this, from, to));
 }
 
@@ -1174,13 +1174,13 @@ Core::RangeMark TextDocument::createRangeMark(int from, int to)
  */
 Core::RangeMark TextDocument::createRangeMark()
 {
-    LOG("TextDocument::createRangeMark");
+    LOG();
     const auto cursor = m_document->textCursor();
     const int start = cursor.selectionStart();
     const int end = cursor.selectionEnd();
 
     if (start == end)
-        spdlog::warn("TextDocument::createRangeMark: Creating a range mark with an empty range.");
+        spdlog::warn("{}: Creating a range mark with an empty range.", FUNCTION_NAME);
 
     LOG_RETURN("rangeMark", createRangeMark(start, end));
 }
@@ -1194,10 +1194,10 @@ Core::RangeMark TextDocument::createRangeMark()
  */
 void TextDocument::selectRangeMark(const Core::RangeMark &mark)
 {
-    LOG("TextDocument::selectRangeMark", LOG_ARG("mark", mark));
+    LOG(LOG_ARG("mark", mark));
 
     if (mark.document() != this) {
-        spdlog::error("Can't use a range mark from another editor.");
+        spdlog::error("{}: Can't use a range mark from another editor.", FUNCTION_NAME);
         return;
     }
 
@@ -1217,7 +1217,7 @@ void TextDocument::selectRangeMark(const Core::RangeMark &mark)
  */
 bool TextDocument::find(const QString &text, int options)
 {
-    LOG("TextDocument::find", LOG_ARG("text", text), options);
+    LOG(LOG_ARG("text", text), options);
     if (options & FindRegexp)
         return findRegexp(text, options);
     else if (options & FindWholeWords)
@@ -1238,7 +1238,7 @@ bool TextDocument::find(const QString &text, int options)
  */
 bool TextDocument::findRegexp(const QString &regexp, int options)
 {
-    LOG("TextDocument::findRegexp", LOG_ARG("text", regexp), options);
+    LOG(LOG_ARG("text", regexp), options);
 
     const auto found = selectRegexpMatch(regexp, options);
     return found.has_value();
@@ -1307,7 +1307,7 @@ auto TextDocument::selectRegexpMatch(
  */
 QString TextDocument::match(const QString &regexp, int options)
 {
-    LOG("TextDocument::match", regexp, options);
+    LOG(regexp, options);
 
     QString captureGroup;
     const auto result = selectRegexpMatch(
@@ -1347,7 +1347,7 @@ QString TextDocument::match(const QString &regexp, int options)
  */
 bool TextDocument::replaceOne(const QString &before, const QString &after, int options)
 {
-    LOG("TextDocument::replaceOne", LOG_ARG("text", before), after, options);
+    LOG(LOG_ARG("text", before), after, options);
 
     auto cursor = m_document->textCursor();
     cursor.movePosition(QTextCursor::Start);
@@ -1399,7 +1399,7 @@ bool TextDocument::replaceOne(const QString &before, const QString &after, int o
  */
 int TextDocument::replaceAll(const QString &before, const QString &after, int options /* = NoFindFlags */)
 {
-    LOG("TextDocument::replaceAll", LOG_ARG("text", before), after, options);
+    LOG(LOG_ARG("text", before), after, options);
     return replaceAll(before, after, options, [](auto) {
         return true;
     });
@@ -1417,13 +1417,13 @@ int TextDocument::replaceAll(const QString &before, const QString &after, int op
 int TextDocument::replaceAllInRange(const QString &before, const QString &after, const Core::RangeMark &range,
                                     int options)
 {
-    LOG("TextDocument::replaceAllInRange", LOG_ARG("text", before), after, range, options);
+    LOG(LOG_ARG("text", before), after, range, options);
     if (!range.isValid()) {
-        spdlog::warn("TextDocument::replaceAllInRange: Invalid range!");
+        spdlog::warn("{}: Invalid range!", FUNCTION_NAME);
         return 0;
     }
     if (range.document() != this) {
-        spdlog::warn("TextDocument::replaceAllInRange: Range is not from this document!");
+        spdlog::warn("{}: Range is not from this document!", FUNCTION_NAME);
         return 0;
     }
 
@@ -1481,7 +1481,7 @@ int TextDocument::replaceAll(const QString &before, const QString &after, int op
  */
 int TextDocument::replaceAllRegexp(const QString &regexp, const QString &after, int options /* = NoFindFlags */)
 {
-    LOG("TextDocument::replaceAllRegexp", LOG_ARG("text", regexp), after, options);
+    LOG(LOG_ARG("text", regexp), after, options);
     return replaceAllRegexp(regexp, after, options, [](auto) {
         return true;
     });
@@ -1500,13 +1500,13 @@ int TextDocument::replaceAllRegexp(const QString &regexp, const QString &after, 
 int TextDocument::replaceAllRegexpInRange(const QString &regexp, const QString &after, const RangeMark &range,
                                           int options /* = NoFindFlags*/)
 {
-    LOG("TextDocument::replaceAllRegexpInRange", LOG_ARG("text", regexp), after, range, options);
+    LOG(LOG_ARG("text", regexp), after, range, options);
     if (!range.isValid()) {
-        spdlog::warn("TextDocument::replaceAllRegexpInRange: Invalid range!");
+        spdlog::warn("{}: Invalid range!", FUNCTION_NAME);
         return 0;
     }
     if (range.document() != this) {
-        spdlog::warn("TextDocument::replaceAllRegexpInRange: Range is not from this document!");
+        spdlog::warn("{}: Range is not from this document!", FUNCTION_NAME);
         return 0;
     }
 
@@ -1613,7 +1613,7 @@ void indentTextInTextEdit(QPlainTextEdit *textEdit, int tabCount)
  */
 void TextDocument::indent(int count)
 {
-    LOG_AND_MERGE("TextDocument::indent", count);
+    LOG_AND_MERGE(count);
     while (count != 0) {
         indentTextInTextEdit(m_document, 1);
         --count;
@@ -1626,7 +1626,7 @@ void TextDocument::indent(int count)
  */
 void TextDocument::removeIndent(int count)
 {
-    LOG_AND_MERGE("TextDocument::removeIndent", count);
+    LOG_AND_MERGE(count);
     while (count != 0) {
         indentTextInTextEdit(m_document, -1);
         --count;
@@ -1635,7 +1635,7 @@ void TextDocument::removeIndent(int count)
 
 void TextDocument::setLineEnding(LineEnding newLineEnding)
 {
-    LOG("TextDocument::setLineEnding", newLineEnding);
+    LOG(newLineEnding);
     if (m_lineEnding == newLineEnding)
         return;
     setHasChanged(true);
@@ -1649,7 +1649,7 @@ void TextDocument::setLineEnding(LineEnding newLineEnding)
  */
 QString TextDocument::indentationAtPosition(int pos)
 {
-    LOG("TextDocument::indentationAtPosition", pos);
+    LOG(pos);
     auto cursor = m_document->textCursor();
     cursor.setPosition(pos);
     cursor.movePosition(QTextCursor::StartOfLine);

--- a/src/core/userdialog.cpp
+++ b/src/core/userdialog.cpp
@@ -50,10 +50,10 @@ UserDialog::UserDialog(QQmlEngine *parent)
  */
 QJSValue UserDialog::getOpenFileName(const QString &caption, const QString &dir, const QString &filters)
 {
-    LOG("UserDialog::getOpenFileName", caption, dir, filters);
+    LOG(caption, dir, filters);
     const QString s = QFileDialog::getOpenFileName(dialogParent(), caption, dir, filters);
     if (!s.isEmpty()) {
-        spdlog::debug("UserDialog::getOpenFileName returns {}", s);
+        spdlog::debug("{} returns {}", FUNCTION_NAME, s);
         return s;
     }
     return QJSValue(QJSValue::NullValue);
@@ -68,10 +68,10 @@ QJSValue UserDialog::getOpenFileName(const QString &caption, const QString &dir,
  */
 QJSValue UserDialog::getSaveFileName(const QString &caption, const QString &dir, const QString &filters)
 {
-    LOG("UserDialog::getSaveFileName", caption, dir, filters);
+    LOG(caption, dir, filters);
     const QString s = QFileDialog::getSaveFileName(dialogParent(), caption, dir, filters);
     if (!s.isEmpty()) {
-        spdlog::debug("UserDialog::getSaveFileName returns {}", s);
+        spdlog::debug("{} returns {}", FUNCTION_NAME, s);
         return s;
     }
     return QJSValue(QJSValue::NullValue);
@@ -85,10 +85,10 @@ QJSValue UserDialog::getSaveFileName(const QString &caption, const QString &dir,
  */
 QJSValue UserDialog::getExistingDirectory(const QString &caption, const QString &dir)
 {
-    LOG("UserDialog::getExistingDirectory", caption, dir);
+    LOG(caption, dir);
     const QString s = QFileDialog::getExistingDirectory(dialogParent(), caption, dir);
     if (!s.isEmpty()) {
-        spdlog::debug("UserDialog::getExistingDirectory returns {}", s);
+        spdlog::debug("{} returns {}", FUNCTION_NAME, s);
         return s;
     }
     return QJSValue(QJSValue::NullValue);
@@ -107,11 +107,11 @@ QJSValue UserDialog::getExistingDirectory(const QString &caption, const QString 
 QJSValue UserDialog::getItem(const QString &title, const QString &label, const QStringList &items, int current,
                              bool editable)
 {
-    LOG("UserDialog::getItem", title, label, items, current, editable);
+    LOG(title, label, items, current, editable);
     bool ok;
     const QString ret = QInputDialog::getItem(dialogParent(), title, label, items, current, editable, &ok);
     if (ok) {
-        spdlog::debug("UserDialog::getItem returns {}", ret);
+        spdlog::debug("{} returns {}", FUNCTION_NAME, ret);
         return ret;
     }
     return QJSValue(QJSValue::NullValue);
@@ -131,12 +131,12 @@ QJSValue UserDialog::getItem(const QString &title, const QString &label, const Q
 QJSValue UserDialog::getDouble(const QString &title, const QString &label, double value, int decimals, double step,
                                double min, double max)
 {
-    LOG("UserDialog::getDouble", title, label, value, decimals, step, min, max);
+    LOG(title, label, value, decimals, step, min, max);
     bool ok;
     const double ret =
         QInputDialog::getDouble(dialogParent(), title, label, value, min, max, decimals, &ok, Qt::WindowFlags(), step);
     if (ok) {
-        spdlog::debug("UserDialog::getDouble returns {}", ret);
+        spdlog::debug("{} returns {}", FUNCTION_NAME, ret);
         return ret;
     }
     return QJSValue(QJSValue::NullValue);
@@ -154,11 +154,11 @@ QJSValue UserDialog::getDouble(const QString &title, const QString &label, doubl
 // clang-format on
 QJSValue UserDialog::getInt(const QString &title, const QString &label, int value, int step, int min, int max)
 {
-    LOG("UserDialog::getInt", title, label, value, step, min, max);
+    LOG(title, label, value, step, min, max);
     bool ok;
     const int ret = QInputDialog::getInt(dialogParent(), title, label, value, min, max, step, &ok);
     if (ok) {
-        spdlog::debug("UserDialog::getInt returns {}", ret);
+        spdlog::debug("{} returns {}", FUNCTION_NAME, ret);
         return ret;
     }
     return QJSValue(QJSValue::NullValue);
@@ -173,11 +173,11 @@ QJSValue UserDialog::getInt(const QString &title, const QString &label, int valu
  */
 QJSValue UserDialog::getText(const QString &title, const QString &label, const QString &text)
 {
-    LOG("UserDialog::getText", title, label, text);
+    LOG(title, label, text);
     bool ok;
     const QString ret = QInputDialog::getText(dialogParent(), title, label, QLineEdit::Normal, text, &ok);
     if (ok) {
-        spdlog::debug("UserDialog::getText returns {}", ret);
+        spdlog::debug("{} returns {}", FUNCTION_NAME, ret);
         return ret;
     }
     return QJSValue(QJSValue::NullValue);
@@ -189,7 +189,7 @@ QJSValue UserDialog::getText(const QString &title, const QString &label, const Q
  */
 void UserDialog::information(const QString &title, const QString &text)
 {
-    LOG("UserDialog::information", title, text);
+    LOG(title, text);
     QMessageBox::information(dialogParent(), title, text);
 }
 
@@ -199,7 +199,7 @@ void UserDialog::information(const QString &title, const QString &text)
  */
 void UserDialog::warning(const QString &title, const QString &text)
 {
-    LOG("UserDialog::warning", title, text);
+    LOG(title, text);
     QMessageBox::warning(dialogParent(), title, text);
 }
 
@@ -209,7 +209,7 @@ void UserDialog::warning(const QString &title, const QString &text)
  */
 void UserDialog::critical(const QString &title, const QString &text)
 {
-    LOG("UserDialog::critical", title, text);
+    LOG(title, text);
     QMessageBox::critical(dialogParent(), title, text);
 }
 

--- a/src/core/utils.cpp
+++ b/src/core/utils.cpp
@@ -45,7 +45,7 @@ Utils::~Utils() = default;
  */
 QString Utils::getEnv(const QString &varName)
 {
-    LOG("Utils::getEnv", varName);
+    LOG(varName);
 
     return QString::fromUtf8(qgetenv(varName.toLatin1()));
 }
@@ -60,7 +60,7 @@ QString Utils::getEnv(const QString &varName)
  */
 QString Utils::getGlobal(const QString &varName)
 {
-    LOG("Utils::getGlobal", varName);
+    LOG(varName);
 
     return m_globals.value(varName);
 }
@@ -75,7 +75,7 @@ QString Utils::getGlobal(const QString &varName)
  */
 void Utils::setGlobal(const QString &varName, const QString &value)
 {
-    LOG("Utils::setGlobal", varName, value);
+    LOG(varName, value);
 
     m_globals.insert(varName, value);
 }
@@ -97,7 +97,7 @@ void Utils::setGlobal(const QString &varName, const QString &value)
  */
 void Utils::addScriptPath(const QString &path)
 {
-    LOG("Utils::addScriptPath", path);
+    LOG(path);
 
     ScriptManager::instance()->addDirectory(path);
 }
@@ -108,7 +108,7 @@ void Utils::addScriptPath(const QString &path)
  */
 void Utils::runScript(const QString &path, bool log)
 {
-    LOG("Utils::runScript", LOG_ARG("path", path), log);
+    LOG(LOG_ARG("path", path), log);
 
     // Run the script synchronously
     ScriptManager::instance()->runScript(path, nlohmann::json::object(), false, log);
@@ -120,7 +120,7 @@ void Utils::runScript(const QString &path, bool log)
  */
 void Utils::sleep(int msecs)
 {
-    LOG("Utils::sleep", msecs);
+    LOG(msecs);
 
     QElapsedTimer timer;
     timer.start();
@@ -136,7 +136,7 @@ void Utils::sleep(int msecs)
 // This function is copied from Qt Creator.
 QString Utils::mktemp(const QString &pattern)
 {
-    LOG("Utils::mktemp", pattern);
+    LOG(pattern);
 
     QString tmp = pattern;
     if (tmp.isEmpty())
@@ -155,7 +155,7 @@ QString Utils::mktemp(const QString &pattern)
         return {};
     file.close();
 
-    spdlog::debug("Utils::mktemp created {}", tmp);
+    spdlog::debug("{}: created {}", FUNCTION_NAME, tmp);
     return file.fileName();
 }
 
@@ -174,7 +174,7 @@ QString Utils::mktemp(const QString &pattern)
  */
 QString Utils::convertCase(const QString &str, Case from, Case to)
 {
-    LOG("Utils::convertCase", str, from, to);
+    LOG(str, from, to);
     return ::Utils::convertCase(str, static_cast<::Utils::Case>(from), static_cast<::Utils::Case>(to));
 }
 
@@ -184,7 +184,7 @@ QString Utils::convertCase(const QString &str, Case from, Case to)
  */
 void Utils::copyToClipboard(const QString &text)
 {
-    LOG("Utils::copyToClipboard", text);
+    LOG(text);
     auto clipboard = QApplication::clipboard();
     clipboard->setText(text);
 }
@@ -203,7 +203,7 @@ void Utils::copyToClipboard(const QString &text)
 // The readonly C++ attribute has the same functionality as the readonly MIDL attribute.
 QStringList Utils::cppKeywords()
 {
-    LOG("Utils::cppKeywords");
+    LOG();
     return QStringList {"alignas",
                         "alignof",
                         "and",
@@ -299,7 +299,7 @@ QStringList Utils::cppKeywords()
  */
 QStringList Utils::cppPrimitiveTypes()
 {
-    LOG("Utils::cppPrimitiveTypes");
+    LOG();
     return QStringList {"int",  "long",    "short",    "void",     "float",  "double",
                         "char", "char8_t", "char16_t", "char32_t", "wchar_t"};
 }

--- a/src/gui/apiexecutorwidget.cpp
+++ b/src/gui/apiexecutorwidget.cpp
@@ -288,7 +288,7 @@ void APIExecutorWidget::executeAPI(Core::Document *document, const QByteArray &n
                                              genericArgs.value(5), genericArgs.value(6), genericArgs.value(7),
                                              genericArgs.value(8), genericArgs.value(9));
     if (!success)
-        spdlog::error("Error trying to execute the function {}", name);
+        spdlog::error("{}: Error trying to execute the function {}", FUNCTION_NAME, name);
 }
 
 void APIExecutorWidget::open()

--- a/src/gui/optionsdialog.cpp
+++ b/src/gui/optionsdialog.cpp
@@ -235,7 +235,7 @@ void OptionsDialog::initializeCppSettings()
             if (model->insertRows(0, 1)) {
                 model->setData(model->index(0), excludeMacro);
             } else {
-                spdlog::warn("OptionsDialog::excludeMacro: Failed to create new row!");
+                spdlog::warn("{}: OptionsDialog::excludeMacro: Failed to create new row!", FUNCTION_NAME);
             }
         }
     });

--- a/src/gui/scriptlistpanel.cpp
+++ b/src/gui/scriptlistpanel.cpp
@@ -93,7 +93,7 @@ void ScriptListPanel::runScript(const QModelIndex &index)
     const auto fileName = index.data(Core::ScriptModel::PathRole).toString();
 
     if (fileName.isEmpty()) {
-        spdlog::warn("ScriptListPanel::runScript - fileName is empty");
+        spdlog::warn("{}: fileName is empty", FUNCTION_NAME);
         return;
     }
 

--- a/src/gui/scriptpanel.cpp
+++ b/src/gui/scriptpanel.cpp
@@ -154,7 +154,7 @@ void ScriptPanel::openScript()
         QFileInfo fi(m_fileName);
         m_scriptName->setText(fi.fileName());
     } else {
-        spdlog::error("Error reading script - can't open the file for reading.");
+        spdlog::error("{}: Error reading script - can't open the file for reading.", FUNCTION_NAME);
     }
 }
 
@@ -207,7 +207,7 @@ void ScriptPanel::saveScript()
         if (isQml && text.contains("ScriptDialog"))
             createDialogFile();
     } else {
-        spdlog::error("Error saving script - can't open the file for writing.");
+        spdlog::error("{}: Error saving script - can't open the file for writing.", FUNCTION_NAME);
     }
 }
 
@@ -226,7 +226,7 @@ void ScriptPanel::editDialog()
     if (!QDesktopServices::openUrl(QString("file:///%1").arg(uiFileName))) {
         QMessageBox::information(this, "Script Dialog Edition",
                                  "In order to edit the dialog, you need to install the Qt Designer tool.");
-        spdlog::error("Error editing dialog - Qt Designer is not found.");
+        spdlog::error("{}: Error editing dialog - Qt Designer is not found.", FUNCTION_NAME);
     }
 }
 
@@ -244,7 +244,7 @@ QString ScriptPanel::createDialogFile()
     QString uiFileName = fi.absolutePath() + '/' + fi.baseName() + ".ui";
 
     if (!QFile::exists(uiFileName) && !QFile::copy(":/gui/default-dialog.ui", uiFileName)) {
-        spdlog::error("Error creating dialog - can't create the dialog file.");
+        spdlog::error("{}: Error creating dialog - can't create the dialog file.", FUNCTION_NAME);
         return {};
     }
     return uiFileName;
@@ -268,7 +268,7 @@ void ScriptPanel::runScript()
         file.close();
         Core::ScriptManager::instance()->runScript(file.fileName(), false, false);
     } else {
-        spdlog::error("Error running script - can't save to temporary file.");
+        spdlog::error("{}: Error running script - can't save to temporary file.", FUNCTION_NAME);
     }
 }
 

--- a/src/gui/slintview.cpp
+++ b/src/gui/slintview.cpp
@@ -67,7 +67,7 @@ SlintView::~SlintView()
 void SlintView::runSlint()
 {
     if (m_process && m_process->state() == QProcess::Running) {
-        spdlog::warn("Slint-viewer process is already running");
+        spdlog::warn("{}: Slint-viewer process is already running", FUNCTION_NAME);
         return;
     }
 

--- a/src/lsp/client.cpp
+++ b/src/lsp/client.cpp
@@ -83,7 +83,7 @@ bool Client::initialize(const QString &rootPath)
     if (!m_backend->start())
         return false;
 
-    spdlog::debug("LSP server started in: {}", rootPath);
+    spdlog::debug("{}: LSP server started in: {}", FUNCTION_NAME, rootPath);
 
     InitializeRequest request;
     request.id = m_nextRequestId++;
@@ -254,14 +254,14 @@ void Client::setState(State newState)
 bool Client::initializeCallback(InitializeRequest::Response response)
 {
     if (!response.isValid() || response.error) {
-        spdlog::error("Error initializing the server");
+        spdlog::error("{}: Error initializing the server", FUNCTION_NAME);
         setState(Error);
         return false;
     }
 
     m_serverCapabilities = response.result->capabilities;
     m_backend->sendNotification(InitializedNotification());
-    spdlog::debug("LSP server initialized");
+    spdlog::debug("{}: LSP server initialized", FUNCTION_NAME);
     setState(Initialized);
     return true;
 }
@@ -269,13 +269,13 @@ bool Client::initializeCallback(InitializeRequest::Response response)
 bool Client::shutdownCallback(ShutdownRequest::Response response)
 {
     if (!response.isValid() || response.error) {
-        spdlog::error("Error shutting down the server");
+        spdlog::error("{}: Error shutting down the server", FUNCTION_NAME);
         setState(Error);
         return false;
     }
 
     m_backend->sendNotification(ExitNotification());
-    spdlog::debug("LSP server exited");
+    spdlog::debug("{}: LSP server exited", FUNCTION_NAME);
     setState(Shutdown);
     return true;
 }

--- a/src/rccore/rc_convert.cpp
+++ b/src/rccore/rc_convert.cpp
@@ -915,7 +915,7 @@ QString convertLanguageToCode(const QString &name)
             }
         }
     }
-    spdlog::error("Unknown language name conversion {} ", name);
+    spdlog::error("{}: Unknown language name conversion {} ", FUNCTION_NAME, name);
     return "en";
 }
 

--- a/src/treesitter/node.cpp
+++ b/src/treesitter/node.cpp
@@ -54,7 +54,7 @@ QString Node::fieldNameForChild(const Node &child) const
     //         result = name;
     //     }
     // } else {
-    //     spdlog::warn("Node::fieldNameForChild - given node is not a child!");
+    //     spdlog::warn("{}: given node is not a child!", FUNCTION_NAME);
     // }
     //
     // However, the code produces incorrect field names in a few cases.
@@ -105,7 +105,7 @@ QString Node::fieldNameForChild(const Node &child) const
     ts_tree_cursor_delete(&cursor);
 
     if (!found) {
-        spdlog::warn("Node::fieldNameForChild - given node is not a child!");
+        spdlog::warn("{}: given node is not a child!", FUNCTION_NAME);
     }
 
     return result;

--- a/src/treesitter/predicates.cpp
+++ b/src/treesitter/predicates.cpp
@@ -447,7 +447,7 @@ void Predicates::findMessageMap() const
     }
 
     if (!m_rootNode.has_value()) {
-        spdlog::warn("Predicates::findMessageMap: No rootNode!");
+        spdlog::warn("Predicate: #in_message_map? - No rootNode!");
         return;
     }
 

--- a/src/utils/log.h
+++ b/src/utils/log.h
@@ -11,4 +11,43 @@
 #pragma once
 
 #include "qt_fmt_format.h"
+
+#include <QRegularExpression>
+#include <source_location>
 #include <spdlog/spdlog.h>
+
+/**
+ * Format the std::source_location::current().function_name() return value
+ * to a simplified 'className::functionName' string value.
+ * The FUNCTION_NAME macro is meant to be called by spdlog to point to the function location.
+ * e.g: spdlog::error("{}: {} - cannot convert", FUNCTION_NAME, path);
+ */
+
+#define FUNCTION_NAME Core::formatToClassNameFunctionName(std::source_location::current())
+
+namespace Core {
+
+inline QString formatToClassNameFunctionName(const std::source_location &location)
+{
+    // Get the functionName.
+    // str = e.g: "QVariant Core::Settings::value(QString, const QVariant&) const"
+    QString str(location.function_name());
+
+    // Extract the section before the arguments list.
+    int openParenthesisIndex = str.indexOf("(");
+    str = str.mid(0, openParenthesisIndex);
+    // Split (whitespace and double columns).
+    static const QRegularExpression splitRegexp("\\s+|::");
+    QStringList sections = str.split(splitRegexp);
+
+    // Assert in case we have less than 2 elements.
+    Q_ASSERT(sections.size() >= 2);
+
+    // Keep the 2 last elements of the list, remove the leading symbols.
+    sections = sections.mid(sections.size() - 2);
+    static const QRegularExpression symbolsRegexp("[*&]");
+    str = sections[0].remove(symbolsRegexp) + "::" + sections[1];
+    return str;
+}
+
+} // namespace Core


### PR DESCRIPTION
- **fix: handle escaped characters when reading XML files**
- **feat: parse ribbon description files for RC files**
- **ci: Remove the reference to base_ref in docs job**
- **.codespellrc - add codespell configuration**
- **fix: deleteLine method name in logging**
- **chore: cleanup gitreview config file**
- **docs: clarify the difference between Project::get and Project::open**
- **fix: cleanup the Ribbon API and documentation**
- **ci: Install plantuml plugin before building docs**
- **feat: Create a JsonDocument**
- **fix: Fix message map extraction when namespaces are used**
- **fix: put everything from utils/strings.h into the namespace Utils**
- **chore: Reduce workspace extensions for VSCode**
- **feat: add option to return the settings from the CLI**
- **docs: Cleanup documentation**
- **feat: add API to create a ui file in QtUiDocument**
- **feat: Add utility class to help write Qt Ui files**
- **refactor: move back the frame conversion to code**
- **refactor: remove the rc2ui.js file, conversion is now static**
- **refactor: increment duplicate ids in RcFile**
- **fix: rename `strings.h` into `string_helper.h`**
- **feat!: refactor the ScriptDialog API for progressbar**
- **chore: rename ConversionProgressDialog into ScriptProgressDialog**
- **feat!: Remove the uiFilePath property from ScriptDialog**
- **test: add tests for the examples**
- **feat: add support for QmlJs via tree-sitter-qmljs**
- **refactor(cmake): Move version into version.txt**
- **fix(tests): update mfc-utils for tests to pass**
- **chore: Cleanup unused includes**
- **chore: Fix std::move usage with const variables**
- **chore: Remove unescessary ;**
- **chore: Remove some copy, use const & when needed**
- **chore: Multiple small cleanups**
- **chore: Const-ify some methods/variables**
- **fix: use /O3 with MSVC rather than -O3**
- **fix: adapt optimization compilation to microsoft compiler**
- **chore: Cleanup CMake targets**
- **fix: use correct variable for toolButton**
- **docs(example): example script to get/set data**
- **feat: introduce Qml to parser**
- **fix: we build against qt6 only now (#78)**
- **fix: Remove version from import**
- **chore: Add missing license to examples**
- **feat: Add ribbon to the RcViewer**
- **feat: add a ribbon model for rcviewer"**
- **fix: default ui windowTitle is "Form" => it can be translated => remove it (#81)**
- **ci: Add release-please workflow**
- **fix(build): Fix debug build on Windows**
- **fix: modification of the setTranslation function for the case where the node is untranslated**
- **fix: const'ify value in knutstyle**
- **fix: const'ify pointer**
- **fix: in qt6 QVector is an alias to QList**
- **refactor: reduce LSP dependencies in Core**
- **docs: review the Utils API**
- **docs: remove old LSP API**
- **fix(docs): Fix an issue with `array<>` in doc**
- **docs: Review the item's API**
- **docs: Review the `Document` and `Project` API**
- **refactor: Add logging for UserDialog return values**
- **chore(ci): Use GitHub upload-pages-artifact and deploy-pages actions**
- **feat: allow to search string in qttsview**
- **refactor!: Rename Script QML module to Knut**
- **chore(ci): Remove pre_commit job from GH Actions**
- **fix: Use Qt_QPA_PLATFORM=offscreen for testing**
- **fix: add stdset="0" we don't want to generate property**
- **chore(cmake): Re-enable docs target by default**
- **refactor!: Change the test API for scripts**
- **chore: update mfc-utils and photonwidgets sub-modules**
- **fix: allow to replace by empty string (=> remove text)**
- **fix: save settings file in different directory in testing mode**
- **fix: Fix saving stringlist in Settings via script**
- **feat: Select Smaller/Larger/Next/Previous Syntax Nodes (#105)**
- **chore: Bump version of photonwidgets**
- **docs: Review QtTsDocument API**
- **fix: Add missing properties to ScriptRunner::isProperty**
- **docs: Review RcDocument API**
- **refactor!: Remove TextLocation class**
- **refactor!: Remove TextRange class**
- **feat: Add a code view with button for TreeSitter**
- **refactor: Improve document toolbar**
- **chore: Add missing licenses for the icons used inside the application**
- **fix: Fix crash in TreeSitter inspector with non-code document**
- **fix: Delete the TreeSitter inspector when closed**
- **feat: Skip macros in C++ during parsing (#116)**
- **feat: added line property for a message node (#122)**
- **feat: add a method to change the context of a message (#121)**
- **chore(docs): Fix & Improve contribution docs**
- **chore: update mfc-utils sub-module (#124)**
- **feat: Add symbol listing for Qml (#79)**
- **fix: save settings on exit (#125)**
- **chore: update mfc-utils sub-module**
- **feat: improve nextStep API in ScriptDialog (#129)**
- **feat: Add TypedSymbol**
- **fix: Capturing of return types in FunctionSymbol**
- **build: Fix include issue with TreeSitter and unicode**
- **fix: do not run tests if the path to the directory doesn't exist**
- **fix: improve script performance by changing QTreeView settings**
- **fix: Make Symbols & query... calls consistent**
- **fix: simplify the API documentation (#132)**
- **feat: Scheme syntax highlighting for TreeSitter**
- **fix!: Remove treesitter transformations**
- **feat: add a way to initialize script dialog from command line (#136)**
- **fix: change syntax of comments to remove warning (#139)**
- **chore: update mfc-utils sub-module (#140)**
- **feat: Handle QTextEdit in the ScriptDialogItem (#141)**
- **fix: flush spdlog messages also when logging to stderr (#142)**
- **fix: exit knut if there is an error in qml test (#147)**
- **fix: remove unused forward declaration**
- **docs: Note Windows build issues, provide steps to resolve (#144)**
- **fix: allows describing type documentation with nested brackets and commas**
- **feat: Add reuse and fix lint issues**
- **feat: Saving & loading TS queries in inspector**
- **feat: Custom treesitter grammar**
- **refactor: Use std::source_location for the LOG**
