### PR TITLE
feat: add a way to display log in a ScriptDialog

### DIFF
--- a/docs/API/knut/scriptdialog.md
+++ b/docs/API/knut/scriptdialog.md
@@ -22,6 +22,7 @@ import Knut
 ||**[firstStep](#firstStep)**(string firstStep)|
 ||**[nextStep](#nextStep)**(string title)|
 ||**[runSteps](#runSteps)**(function generator)|
+||**[setDisplayLogs](#setDisplayLogs)**(const QString &level)|
 ||**[setStepCount](#setStepCount)**(int stepCount)|
 ||**[verify](#verify)**(bool value, string message = {})|
 
@@ -170,6 +171,11 @@ function convert() {
    runSteps(conversionSteps())
 }
 ```
+
+#### <a name="setDisplayLogs"></a>**setDisplayLogs**(const QString &level)
+
+This method enables real-time logging display in the progress dialog by configuring a QPlainTextEdit widget as a log
+output panel. It filters the logs to show only those that are of the specified log level or higher.
 
 #### <a name="setStepCount"></a>**setStepCount**(int stepCount)
 

--- a/examples/ex_gui_interactive.qml
+++ b/examples/ex_gui_interactive.qml
@@ -21,6 +21,7 @@ ScriptDialog {
         // This can be done using the `stepCount` property of ScriptDialog
         // Note: if you don't set the step count, a moving scrollbar will be displayed
         setStepCount(5);
+        setDisplayLogs("info");
 
         // 3) Initialize the first step using `firstStep` and run the different commands for this step
         firstStep("Step 1...");

--- a/src/core/scriptdialogitem.h
+++ b/src/core/scriptdialogitem.h
@@ -62,6 +62,8 @@ public:
     Q_INVOKABLE void compare(const QJSValue &actual, const QJSValue &expected, QString message = {});
     Q_INVOKABLE void verify(bool value, QString message = {});
 
+    Q_INVOKABLE void setDisplayLogs(const QString &level);
+
 public slots:
     void setStepCount(int stepCount);
     void done(int code) override;

--- a/src/core/scriptprogressdialog.cpp
+++ b/src/core/scriptprogressdialog.cpp
@@ -21,6 +21,7 @@ ScriptProgressDialog::ScriptProgressDialog(QWidget *parent)
     setAttribute(Qt::WA_DeleteOnClose);
 
     ui->buttonBox->button(QDialogButtonBox::Yes)->setText(tr("Continue"));
+    ui->logsWidget->hide();
     connect(ui->buttonBox, &QDialogButtonBox::accepted, this, &ScriptProgressDialog::apply);
     connect(ui->buttonBox, &QDialogButtonBox::rejected, this, &ScriptProgressDialog::abort);
 }
@@ -62,4 +63,9 @@ int ScriptProgressDialog::value() const
 void ScriptProgressDialog::setReadOnly(bool readOnly)
 {
     ui->buttonBox->setEnabled(!readOnly);
+}
+
+QPlainTextEdit *ScriptProgressDialog::logsWidget()
+{
+    return ui->logsWidget;
 }

--- a/src/core/scriptprogressdialog.h
+++ b/src/core/scriptprogressdialog.h
@@ -15,6 +15,7 @@
 namespace Ui {
 class ScriptProgressDialog;
 }
+class QPlainTextEdit;
 
 class ScriptProgressDialog : public QDialog
 {
@@ -33,6 +34,8 @@ public:
     void setReadOnly(bool readOnly);
 
     int value() const;
+
+    QPlainTextEdit *logsWidget();
 
 signals:
     void apply();

--- a/src/core/scriptprogressdialog.ui
+++ b/src/core/scriptprogressdialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>360</width>
-    <height>94</height>
+    <height>189</height>
    </rect>
   </property>
   <property name="minimumSize">
@@ -47,6 +47,9 @@
       <bool>false</bool>
      </property>
     </widget>
+   </item>
+   <item row="3" column="0">
+    <widget class="QPlainTextEdit" name="logsWidget"/>
    </item>
   </layout>
  </widget>


### PR DESCRIPTION
Added a QPlainTextEdit widget to allow real-time log display in the user interface. The actual code did not allow windows users to view logs when launching knut from the command line.

The QPlainTextEdit can be made visible using the qml setDisplayLogs method and taking as parameter the minimum log level that we want to have.

Fixes https://github.com/KDAB/knut/issues/26