### PR TITLE
improve search in document

### DIFF
--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -28,6 +28,8 @@ set(PROJECT_SOURCES
     gui_constants.h
     guisettings.h
     guisettings.cpp
+    highlightsearchdelegate.h
+    highlightsearchdelegate.cpp
     historypanel.h
     historypanel.cpp
     imageview.h

--- a/src/gui/findwidget.cpp
+++ b/src/gui/findwidget.cpp
@@ -11,8 +11,12 @@
 #include "findwidget.h"
 #include "core/logger.h"
 #include "core/project.h"
+#include "core/qttsdocument.h"
+#include "core/qtuidocument.h"
 #include "core/textdocument.h"
 #include "guisettings.h"
+#include "qttsview.h"
+#include "qtuiview.h"
 #include "ui_findwidget.h"
 
 #include <QAction>
@@ -86,11 +90,35 @@ QString FindWidget::findString()
 
 void FindWidget::findNext()
 {
+    auto qtUiDocument = qobject_cast<Core::QtUiDocument *>(Core::Project::instance()->currentDocument());
+    if (qtUiDocument) {
+        Q_EMIT findRequested(ui->findEdit->text(), Core::TextDocument::NoFindFlags);
+        return;
+    }
+
+    auto qtTsDocument = qobject_cast<Core::QtTsDocument *>(Core::Project::instance()->currentDocument());
+    if (qtTsDocument) {
+        Q_EMIT findRequested(ui->findEdit->text(), Core::TextDocument::NoFindFlags); // default is FindForward
+        return;
+    }
+
     find(findFlags());
 }
 
 void FindWidget::findPrevious()
 {
+    auto qtUiDocument = qobject_cast<Core::QtUiDocument *>(Core::Project::instance()->currentDocument());
+    if (qtUiDocument) {
+        Q_EMIT findRequested(ui->findEdit->text(), Core::TextDocument::FindBackward);
+        return;
+    }
+
+    auto qtTsDocument = qobject_cast<Core::QtTsDocument *>(Core::Project::instance()->currentDocument());
+    if (qtTsDocument) {
+        Q_EMIT findRequested(ui->findEdit->text(), Core::TextDocument::FindBackward);
+        return;
+    }
+
     find(findFlags() | Core::TextDocument::FindBackward);
 }
 
@@ -151,6 +179,21 @@ void FindWidget::replace(bool onlyOne)
         else
             textDocument->replaceAll(before, after, findFlags());
     }
+}
+
+void FindWidget::hideEvent(QHideEvent *event)
+{
+    Q_EMIT findWidgetClosed();
+    QWidget::hideEvent(event);
+}
+
+void FindWidget::showReplaceFeature(bool show)
+{
+    // We don't want to use a wrapping frame here due to layouting issues...
+    ui->replaceWithLabel->setVisible(show);
+    ui->replaceEdit->setVisible(show);
+    ui->replaceAllbutton->setVisible(show);
+    ui->replaceButton->setVisible(show);
 }
 
 } // namespace Gui

--- a/src/gui/findwidget.h
+++ b/src/gui/findwidget.h
@@ -31,6 +31,15 @@ public:
 
     void open();
 
+    void showReplaceFeature(bool show = true);
+
+signals:
+    void findRequested(const QString &text, int options);
+    void findWidgetClosed();
+
+protected:
+    void hideEvent(QHideEvent *event) override;
+
 private:
     int findFlags() const;
     QString findString();

--- a/src/gui/findwidget.ui
+++ b/src/gui/findwidget.ui
@@ -117,14 +117,14 @@
     </layout>
    </item>
    <item row="1" column="0">
-    <widget class="QLabel" name="label_2">
+    <widget class="QLabel" name="replaceWithLabel">
      <property name="text">
       <string>Replace with:</string>
      </property>
     </widget>
    </item>
    <item row="0" column="0">
-    <widget class="QLabel" name="label">
+    <widget class="QLabel" name="findLabel">
      <property name="text">
       <string>Find:</string>
      </property>

--- a/src/gui/highlightsearchdelegate.cpp
+++ b/src/gui/highlightsearchdelegate.cpp
@@ -1,0 +1,83 @@
+/*
+  This file is part of Knut.
+
+  SPDX-FileCopyrightText: 2024 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+
+  SPDX-License-Identifier: GPL-3.0-only
+
+  Contact KDAB at <info@kdab.com> for commercial licensing options.
+*/
+
+#include "highlightsearchdelegate.h"
+#include <QPainter>
+
+namespace Gui {
+
+HighlightSearchDelegate::HighlightSearchDelegate(QObject *parent)
+    : QItemDelegate(parent)
+{
+}
+
+void HighlightSearchDelegate::setSearchText(const QString &searchText, int offset)
+{
+    m_searchText = searchText;
+    m_offset = offset;
+}
+
+void HighlightSearchDelegate::paint(QPainter *painter, const QStyleOptionViewItem &option,
+                                    const QModelIndex &index) const
+{
+    QString text = index.data().toString();
+    if (m_searchText.isEmpty() || !text.contains(m_searchText, Qt::CaseInsensitive)) {
+        QItemDelegate::paint(painter, option, index);
+        return;
+    }
+
+    // Check for multiline strings
+    QStringList multilineStrings = text.split("\n", Qt::SkipEmptyParts);
+    bool isMultiline = multilineStrings.count() > 1;
+    if (isMultiline) {
+        // Make it a one line text for the search highlight,
+        // otherwise the painting is error prone (needs too much manipulation).
+        // That does not impact the model itself.
+        text = text.replace("\n", " - ");
+    }
+    // Find the substring to highlight
+    const QRegularExpression regex(m_searchText, QRegularExpression::CaseInsensitiveOption);
+    int start = regex.match(text).capturedStart();
+    int end = start + regex.match(text).capturedLength();
+
+    // Calculate the drawing positions.
+    // The TreeViews or TableView display its Items excentred in relation to the left side of the cell.
+    // Correct the x position accordingly using the caller offset value.
+    int x = option.rect.left() + m_offset;
+    int y = option.rect.top();
+    int height = option.rect.height();
+    int width = painter->fontMetrics().horizontalAdvance(text.left(start));
+
+    // Paint the seach result string 'bold'.
+    QFont highlightFont = option.font;
+    highlightFont.setBold(true);
+
+    painter->save();
+    // Make sure we don't paint over the selected item highlighted background.
+    if (option.state & QStyle::State_Selected) {
+        // Set the background color to the selection color
+        painter->fillRect(option.rect, option.palette.brush(QPalette::Active, QPalette::Highlight));
+    }
+
+    painter->drawText(x, y, width, height, option.displayAlignment, text.left(start));
+    // Paint the searched string with bold font.
+    painter->setFont(highlightFont);
+    x += width;
+    width = painter->fontMetrics().horizontalAdvance(text.mid(start, end - start));
+    painter->drawText(x, y, width, height, option.displayAlignment, text.mid(start, end - start));
+    // Reset the painter font to original font.
+    painter->setFont(option.font);
+    x += width;
+    width = painter->fontMetrics().horizontalAdvance(text.right(text.length() - end));
+    painter->drawText(x, y, width, height, option.displayAlignment, text.right(text.length() - end));
+    painter->restore();
+}
+
+} // namespace Gui

--- a/src/gui/highlightsearchdelegate.h
+++ b/src/gui/highlightsearchdelegate.h
@@ -1,0 +1,34 @@
+/*
+  This file is part of Knut.
+
+  SPDX-FileCopyrightText: 2024 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+
+  SPDX-License-Identifier: GPL-3.0-only
+
+  Contact KDAB at <info@kdab.com> for commercial licensing options.
+*/
+
+#pragma once
+
+#include <QItemDelegate>
+
+namespace Gui {
+
+class HighlightSearchDelegate : public QItemDelegate
+{
+    Q_OBJECT
+
+public:
+    explicit HighlightSearchDelegate(QObject *parent = nullptr);
+
+    void setSearchText(const QString &searchText, int offset = 0);
+
+protected:
+    void paint(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const override;
+
+private:
+    QString m_searchText;
+    int m_offset;
+};
+
+} // namespace Gui

--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -101,6 +101,7 @@ private:
 
     void updateActions();
     void updateScriptActions();
+    void updateFindWidgetDisplay();
 
     void initProject(const QString &path);
     void openDocument(const QModelIndex &index);

--- a/src/gui/qttsview.cpp
+++ b/src/gui/qttsview.cpp
@@ -9,7 +9,8 @@
 */
 
 #include "qttsview.h"
-#include "core/qttsdocument.h"
+#include "findwidget.h"
+#include "highlightsearchdelegate.h"
 
 #include <QAbstractTableModel>
 #include <QHeaderView>
@@ -129,6 +130,8 @@ QtTsView::QtTsView(QWidget *parent)
     auto mainWidgetLayout = new QVBoxLayout(this);
     m_tableView->verticalHeader()->hide();
     m_tableView->setSelectionBehavior(QAbstractItemView::SelectRows);
+    // Set the delegate
+    m_tableView->setItemDelegate(new HighlightSearchDelegate(this));
     mainWidgetLayout->addWidget(m_tableView);
     mainWidgetLayout->addWidget(m_searchLineEdit);
     m_searchLineEdit->setPlaceholderText(tr("Filter..."));
@@ -147,10 +150,25 @@ void QtTsView::setTsDocument(Core::QtTsDocument *document)
         m_document->disconnect(this);
 
     m_document = document;
-    if (m_document)
+    if (m_document) {
         connect(m_document, &Core::QtTsDocument::fileUpdated, this, &QtTsView::updateView);
-
+    }
     updateView();
+}
+
+void QtTsView::setFindWidget(FindWidget *findWidget)
+{
+    Q_ASSERT(findWidget);
+
+    // Connections
+    connect(findWidget, &FindWidget::findRequested, this, &QtTsView::search);
+
+    auto updateDisplay = [this]() {
+        search(""); // Reset delegate highlighting
+        m_tableView->viewport()->update();
+        m_tableView->clearSelection();
+    };
+    connect(findWidget, &FindWidget::findWidgetClosed, this, updateDisplay);
 }
 
 void QtTsView::updateView()
@@ -168,6 +186,71 @@ void QtTsView::updateView()
     m_tableView->horizontalHeader()->setSectionResizeMode(QtTsModelView::TsColumn::Translation, QHeaderView::Fixed);
     m_tableView->horizontalHeader()->setSectionResizeMode(QtTsModelView::TsColumn::Context, QHeaderView::Interactive);
     m_tableView->horizontalHeader()->setStretchLastSection(true);
+}
+
+void QtTsView::search(const QString &searchText, int options)
+{
+    // Retrieve the text margin for the text inside a cell depending on the style.
+    QStyle *widgetStyle = style();
+    // Ref: See textMargin - QItemDelegate::drawDisplay.
+    const int textMargin = widgetStyle->pixelMetric(QStyle::PM_FocusFrameHMargin) + 1;
+
+    // Search only in case the search was not already processed (inclusive empty string search).
+    if (searchText != m_currentSearchText || !m_initialSearchProcessed) {
+        // Colorize search hits (This gives an overview over the search result)
+        // textMargin: Displays the highlighted data indented with the style text margin value.
+        static_cast<HighlightSearchDelegate *>(m_tableView->itemDelegate())->setSearchText(searchText, textMargin);
+        // Update display.
+        m_tableView->viewport()->update();
+        // Search...
+        m_currentSearchResult = searchModel(searchText, m_tableView->model());
+        // Reset the search index.
+        m_currentSearchIndex = 0;
+        m_initialSearchProcessed = true;
+    } else { // Search was already processed. Handle options (Backward, Forward)
+        if (!m_currentSearchResult.isEmpty()) {
+            int index;
+            switch (options) {
+            case Core::TextDocument::FindBackward: {
+                index = m_currentSearchIndex - 1;
+                // if it is the first match continue with the last match.
+                index = (index >= 0) ? index : m_currentSearchResult.count() - 1;
+                break;
+            }
+            default: { // Default is FindForward
+                index = m_currentSearchIndex + 1;
+                // if it is the last match continue with the first match.
+                index = (index < m_currentSearchResult.count()) ? index : 0;
+                break;
+            }
+            }
+            // Update the current search index
+            m_currentSearchIndex = index;
+        }
+    }
+    // Update the current search text
+    m_currentSearchText = searchText;
+    // Select (highlight) the cell that matched, as the current index.
+    if (!m_currentSearchResult.isEmpty()) {
+        m_tableView->selectionModel()->setCurrentIndex(m_currentSearchResult[m_currentSearchIndex],
+                                                       QItemSelectionModel::SelectCurrent);
+    }
+}
+
+QModelIndexList QtTsView::searchModel(const QString &searchText, const QAbstractItemModel *model) const
+{
+    QModelIndexList searchResults;
+    for (int row = 0; row < model->rowCount(); ++row) {
+        for (int column = 0; column < model->columnCount(); ++column) {
+            const QModelIndex index = model->index(row, column);
+            const QString data = model->data(index).toString();
+            if ((searchText.isEmpty() && data == searchText)
+                || (!searchText.isEmpty() && data.contains(searchText, Qt::CaseInsensitive))) {
+                searchResults.append(index);
+            }
+        }
+    }
+    return searchResults;
 }
 
 void QtTsProxy::setFilterText(const QString &str)

--- a/src/gui/qttsview.h
+++ b/src/gui/qttsview.h
@@ -10,31 +10,47 @@
 
 #pragma once
 
+#include "core/qttsdocument.h"
+#include "core/textdocument.h"
+
 #include <QSortFilterProxyModel>
 #include <QWidget>
+
 class QTableView;
 class QLineEdit;
-namespace Core {
-class QtTsDocument;
-}
 
 namespace Gui {
-
+class FindWidget;
 class QtTsProxy;
+
 class QtTsView : public QWidget
 {
     Q_OBJECT
+
 public:
     explicit QtTsView(QWidget *parent = nullptr);
 
     void setTsDocument(Core::QtTsDocument *document);
+    void setFindWidget(FindWidget *findWidget);
+
+public slots:
+    // Accessible from QML
+    void search(const QString &searchText, int option = Core::TextDocument::NoFindFlags);
 
 private:
+    QModelIndexList searchModel(const QString &searchText, const QAbstractItemModel *model) const;
     void updateView();
+
     QTableView *const m_tableView;
     QLineEdit *const m_searchLineEdit;
     Core::QtTsDocument *m_document = nullptr;
     QtTsProxy *const m_contentProxyModel;
     QAbstractItemModel *m_contentModel = nullptr;
+    // Search feature
+    QModelIndexList m_currentSearchResult;
+    QString m_currentSearchText;
+    int m_currentSearchIndex = 0;
+    bool m_initialSearchProcessed = false;
 };
-}
+
+} // namespace Gui

--- a/src/gui/qtuiview.h
+++ b/src/gui/qtuiview.h
@@ -10,33 +10,47 @@
 
 #pragma once
 
+#include "core/qtuidocument.h"
+#include "core/textdocument.h"
+
+#include <QModelIndex>
 #include <QSplitter>
 
 class QTableView;
 class QMdiArea;
 class QMdiSubWindow;
 
-namespace Core {
-class QtUiDocument;
-}
-
 namespace Gui {
+
+class FindWidget;
 
 class QtUiView : public QSplitter
 {
     Q_OBJECT
+
 public:
     explicit QtUiView(QWidget *parent = nullptr);
 
+    void setFindWidget(FindWidget *findWidget);
     void setUiDocument(Core::QtUiDocument *document);
 
+public slots:
+    // Accessible from QML
+    void search(const QString &searchText, int option = Core::TextDocument::NoFindFlags);
+
 private:
+    QModelIndexList searchModel(const QString &searchText, const QAbstractItemModel *model) const;
     void updateView();
 
     QTableView *const m_tableView;
     QMdiArea *const m_previewArea;
     Core::QtUiDocument *m_document = nullptr;
     QMdiSubWindow *m_previewWindow = nullptr;
+    // Search feature
+    QModelIndexList m_currentSearchResult;
+    QString m_currentSearchText;
+    int m_currentSearchIndex = 0;
+    bool m_initialSearchProcessed = false;
 };
 
 } // namespace Gui


### PR DESCRIPTION
- **fix: handle escaped characters when reading XML files**
- **feat: parse ribbon description files for RC files**
- **ci: Remove the reference to base_ref in docs job**
- **.codespellrc - add codespell configuration**
- **fix: deleteLine method name in logging**
- **chore: cleanup gitreview config file**
- **docs: clarify the difference between Project::get and Project::open**
- **fix: cleanup the Ribbon API and documentation**
- **ci: Install plantuml plugin before building docs**
- **feat: Create a JsonDocument**
- **fix: Fix message map extraction when namespaces are used**
- **fix: put everything from utils/strings.h into the namespace Utils**
- **chore: Reduce workspace extensions for VSCode**
- **feat: add option to return the settings from the CLI**
- **docs: Cleanup documentation**
- **feat: add API to create a ui file in QtUiDocument**
- **feat: Add utility class to help write Qt Ui files**
- **refactor: move back the frame conversion to code**
- **refactor: remove the rc2ui.js file, conversion is now static**
- **refactor: increment duplicate ids in RcFile**
- **fix: rename `strings.h` into `string_helper.h`**
- **feat!: refactor the ScriptDialog API for progressbar**
- **chore: rename ConversionProgressDialog into ScriptProgressDialog**
- **feat!: Remove the uiFilePath property from ScriptDialog**
- **test: add tests for the examples**
- **feat: add support for QmlJs via tree-sitter-qmljs**
- **refactor(cmake): Move version into version.txt**
- **fix(tests): update mfc-utils for tests to pass**
- **chore: Cleanup unused includes**
- **chore: Fix std::move usage with const variables**
- **chore: Remove unescessary ;**
- **chore: Remove some copy, use const & when needed**
- **chore: Multiple small cleanups**
- **chore: Const-ify some methods/variables**
- **fix: use /O3 with MSVC rather than -O3**
- **fix: adapt optimization compilation to microsoft compiler**
- **chore: Cleanup CMake targets**
- **fix: use correct variable for toolButton**
- **docs(example): example script to get/set data**
- **feat: introduce Qml to parser**
- **fix: we build against qt6 only now (#78)**
- **fix: Remove version from import**
- **chore: Add missing license to examples**
- **feat: Add ribbon to the RcViewer**
- **feat: add a ribbon model for rcviewer"**
- **fix: default ui windowTitle is "Form" => it can be translated => remove it (#81)**
- **ci: Add release-please workflow**
- **fix(build): Fix debug build on Windows**
- **fix: modification of the setTranslation function for the case where the node is untranslated**
- **fix: const'ify value in knutstyle**
- **fix: const'ify pointer**
- **fix: in qt6 QVector is an alias to QList**
- **refactor: reduce LSP dependencies in Core**
- **docs: review the Utils API**
- **docs: remove old LSP API**
- **fix(docs): Fix an issue with `array<>` in doc**
- **docs: Review the item's API**
- **docs: Review the `Document` and `Project` API**
- **refactor: Add logging for UserDialog return values**
- **chore(ci): Use GitHub upload-pages-artifact and deploy-pages actions**
- **feat: allow to search string in qttsview**
- **refactor!: Rename Script QML module to Knut**
- **chore(ci): Remove pre_commit job from GH Actions**
- **fix: Use Qt_QPA_PLATFORM=offscreen for testing**
- **fix: add stdset="0" we don't want to generate property**
- **chore(cmake): Re-enable docs target by default**
- **refactor!: Change the test API for scripts**
- **chore: update mfc-utils and photonwidgets sub-modules**
- **fix: allow to replace by empty string (=> remove text)**
- **fix: save settings file in different directory in testing mode**
- **fix: Fix saving stringlist in Settings via script**
- **feat: Select Smaller/Larger/Next/Previous Syntax Nodes (#105)**
- **chore: Bump version of photonwidgets**
- **docs: Review QtTsDocument API**
- **fix: Add missing properties to ScriptRunner::isProperty**
- **docs: Review RcDocument API**
- **refactor!: Remove TextLocation class**
- **refactor!: Remove TextRange class**
- **feat: Add a code view with button for TreeSitter**
- **refactor: Improve document toolbar**
- **chore: Add missing licenses for the icons used inside the application**
- **fix: Fix crash in TreeSitter inspector with non-code document**
- **fix: Delete the TreeSitter inspector when closed**
- **feat: Skip macros in C++ during parsing (#116)**
- **feat: added line property for a message node (#122)**
- **feat: add a method to change the context of a message (#121)**
- **chore(docs): Fix & Improve contribution docs**
- **chore: update mfc-utils sub-module (#124)**
- **feat: Add symbol listing for Qml (#79)**
- **fix: save settings on exit (#125)**
- **chore: update mfc-utils sub-module**
- **feat: improve nextStep API in ScriptDialog (#129)**
- **feat: Add TypedSymbol**
- **fix: Capturing of return types in FunctionSymbol**
- **build: Fix include issue with TreeSitter and unicode**
- **fix: do not run tests if the path to the directory doesn't exist**
- **fix: improve script performance by changing QTreeView settings**
- **fix: Make Symbols & query... calls consistent**
- **fix: simplify the API documentation (#132)**
- **feat: Scheme syntax highlighting for TreeSitter**
- **fix!: Remove treesitter transformations**
- **feat: add a way to initialize script dialog from command line (#136)**
- **fix: change syntax of comments to remove warning (#139)**
- **chore: update mfc-utils sub-module (#140)**
- **feat: Handle QTextEdit in the ScriptDialogItem (#141)**
- **fix: flush spdlog messages also when logging to stderr (#142)**
- **fix: exit knut if there is an error in qml test (#147)**
- **fix: remove unused forward declaration**
- **docs: Note Windows build issues, provide steps to resolve (#144)**
- **fix: allows describing type documentation with nested brackets and commas**
- **feat: Add reuse and fix lint issues**
- **feat: Saving & loading TS queries in inspector**
- **feat: Custom treesitter grammar**
- **feat: add a find in files API to Project (#143)**
- **feat: do not update docs if they are not outdated (#148)**
- **feat: Add some more API to JsonDocument (#76)**
- **fix: minor REUSE issues (#153)**
- **feat: add a find in files panel on the GUI (#152)**
- **feat: add a removeLines method in CppDocument (#154)**
- **fix: move LogHighlighter from Gui to Core (#155)**
- **feat: add a way to display log in a ScriptDialog (#157)**
- **fix: move return in the changeValue method to ensure proper execution flow (#156)**
- **fix: use asKeyValueRange() instead of keys() (#159)**
- **feat: improve search in document (#25)**
