### PR TITLE
build: bump Qt minimum version to Qt 6.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,7 +96,7 @@ set(CMAKE_AUTORCC ON)
 
 find_package(QT NAMES Qt6)
 find_package(
-  Qt6
+  Qt6 6.5
   COMPONENTS Widgets Qml Quick Test UiTools
   REQUIRED)
 


### PR DESCRIPTION
Qt 6.5 is the current LTS.

Closes #4
