### PR TITLE
fix: fix crash with Qt 6.8: metaObject() should never be nullptr

### DIFF
--- a/src/core/scriptdialogitem_p.cpp
+++ b/src/core/scriptdialogitem_p.cpp
@@ -17,19 +17,20 @@ namespace Core {
 
 DynamicObject::~DynamicObject()
 {
-    free(m_metaObject);
+    if (m_metaObject != &QObject::staticMetaObject)
+        free(const_cast<QMetaObject *>(m_metaObject));
 }
 
 void DynamicObject::addProperty(const QByteArray &name, const QByteArray &type, QMetaType::Type typeId,
                                 const QVariant &value)
 {
-    Q_ASSERT_X(m_metaObject == nullptr, "addProperty", "Can't add property after calling ready()");
+    Q_ASSERT_X(m_metaObject == &QObject::staticMetaObject, "addProperty", "Can't add property after calling ready()");
     m_properties.emplace_back(DynamicProperty {name, type, typeId, value});
 }
 
 void DynamicObject::ready()
 {
-    Q_ASSERT_X(m_metaObject == nullptr, "ready", "ready() should be called only once.");
+    Q_ASSERT_X(m_metaObject == &QObject::staticMetaObject, "ready", "ready() should be called only once.");
 
     QMetaObjectBuilder builder;
     builder.setSuperClass(&QObject::staticMetaObject);

--- a/src/core/scriptdialogitem_p.h
+++ b/src/core/scriptdialogitem_p.h
@@ -56,7 +56,7 @@ private:
         QVariant variant;
     };
 
-    QMetaObject *m_metaObject = nullptr;
+    const QMetaObject *m_metaObject = &QObject::staticMetaObject;
     std::vector<DynamicProperty> m_properties;
     DataChangedFunc m_dataChangedCallback;
 };


### PR DESCRIPTION
It was null until ready() was called, but before that, any qobject_cast on the object would crash.

In Qt 6.8 QAccessibleWidget looks for "who has widget X as buddy" by iterating over all children() of the parent and doing qobject_cast<QLabel *>, hence this new crash.