### PR TITLE
fix: Do not create new files from the palette

### DIFF
--- a/src/gui/palette.h
+++ b/src/gui/palette.h
@@ -57,11 +57,11 @@ private:
     {
         QString prefix;
         std::unique_ptr<QAbstractItemModel> model;
-        std::function<void(const QVariant &)> selectionFunc;
+        std::function<bool(const QVariant &)> selectionFunc;
         std::function<void()> resetFunc = {};
 
         Selector(QString prefix, std::unique_ptr<QAbstractItemModel> model,
-                 std::function<void(const QVariant &)> selectionFunc, std::function<void()> resetFunc = {})
+                 std::function<bool(const QVariant &)> selectionFunc, std::function<void()> resetFunc = {})
             : prefix(std::move(prefix))
             , model(std::move(model))
             , selectionFunc(std::move(selectionFunc))


### PR DESCRIPTION
The palette is just a way to navigate around, it shouldn't be able to
create new files.
Also keep the palette open if the text does not match (like VS Code).