### PR TITLE
fix: Ensure the find widget's height is minimum

### DIFF
--- a/src/gui/findwidget.cpp
+++ b/src/gui/findwidget.cpp
@@ -160,8 +160,7 @@ void FindWidget::setReplaceVisible(bool show)
     // We don't want to use a wrapping frame here due to layouting issues...
     ui->replaceWithLabel->setVisible(show);
     ui->replaceEdit->setVisible(show);
-    ui->replaceAllbutton->setVisible(show);
-    ui->replaceButton->setVisible(show);
+    ui->replaceButtonWidget->setVisible(show);
 }
 
 } // namespace Gui

--- a/src/gui/findwidget.ui
+++ b/src/gui/findwidget.ui
@@ -6,11 +6,14 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>844</width>
-    <height>53</height>
+    <width>675</width>
+    <height>51</height>
    </rect>
   </property>
   <layout class="QGridLayout" name="gridLayout">
+   <property name="sizeConstraint">
+    <enum>QLayout::SetMinimumSize</enum>
+   </property>
    <property name="leftMargin">
     <number>6</number>
    </property>
@@ -28,6 +31,74 @@
    </property>
    <item row="0" column="1">
     <widget class="QLineEdit" name="findEdit"/>
+   </item>
+   <item row="1" column="1">
+    <widget class="QLineEdit" name="replaceEdit"/>
+   </item>
+   <item row="0" column="0">
+    <widget class="QLabel" name="findLabel">
+     <property name="text">
+      <string>Find:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="QLabel" name="replaceWithLabel">
+     <property name="text">
+      <string>Replace with:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="2">
+    <widget class="QWidget" name="replaceButtonWidget" native="true">
+     <layout class="QHBoxLayout" name="horizontalLayout_3">
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <item>
+       <widget class="QToolButton" name="replaceButton">
+        <property name="text">
+         <string>Replace</string>
+        </property>
+        <property name="autoRaise">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QToolButton" name="replaceAllbutton">
+        <property name="text">
+         <string>Replace All</string>
+        </property>
+        <property name="autoRaise">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <spacer name="replaceSpacer">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+     </layout>
+    </widget>
    </item>
    <item row="0" column="2">
     <layout class="QHBoxLayout" name="horizontalLayout">
@@ -76,60 +147,6 @@
      </item>
     </layout>
    </item>
-   <item row="1" column="1">
-    <widget class="QLineEdit" name="replaceEdit"/>
-   </item>
-   <item row="1" column="2">
-    <layout class="QHBoxLayout" name="horizontalLayout_2">
-     <item>
-      <widget class="QToolButton" name="replaceButton">
-       <property name="text">
-        <string>Replace</string>
-       </property>
-       <property name="autoRaise">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QToolButton" name="replaceAllbutton">
-       <property name="text">
-        <string>Replace All</string>
-       </property>
-       <property name="autoRaise">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <spacer name="replaceSpacer">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-    </layout>
-   </item>
-   <item row="1" column="0">
-    <widget class="QLabel" name="replaceWithLabel">
-     <property name="text">
-      <string>Replace with:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="0">
-    <widget class="QLabel" name="findLabel">
-     <property name="text">
-      <string>Find:</string>
-     </property>
-    </widget>
-   </item>
   </layout>
  </widget>
  <tabstops>
@@ -137,8 +154,6 @@
   <tabstop>replaceEdit</tabstop>
   <tabstop>previousButton</tabstop>
   <tabstop>nextButton</tabstop>
-  <tabstop>replaceButton</tabstop>
-  <tabstop>replaceAllbutton</tabstop>
   <tabstop>closeButton</tabstop>
  </tabstops>
  <resources/>


### PR DESCRIPTION
The find widget height is always minimum, even when the replace line is
hidden.