### PR TITLE
fix: Fix combobox's width for API executor

### DIFF
--- a/src/gui/apiexecutorwidget.ui
+++ b/src/gui/apiexecutorwidget.ui
@@ -59,6 +59,9 @@
      <property name="whatsThis">
       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;API:&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
+     <property name="sizeAdjustPolicy">
+      <enum>QComboBox::AdjustToContents</enum>
+     </property>
     </widget>
    </item>
    <item>


### PR DESCRIPTION
When changing files with the API executor displayed, the combobox didn't
adapt to its content.

Fix #164