### PR TITLE
feat: Use enum values rather than int for recording

### DIFF
--- a/docs/API/knut/rcdocument.md
+++ b/docs/API/knut/rcdocument.md
@@ -34,10 +34,10 @@ import Knut
 |array&lt;[Action](../knut/action.md)> |**[actionsFromMenu](#actionsFromMenu)**(string menuId)|
 |array&lt;[Action](../knut/action.md)> |**[actionsFromMenuForLanguage](#actionsFromMenuForLanguage)**(string menuId, string language)|
 |array&lt;[Action](../knut/action.md)> |**[actionsFromToolbar](#actionsFromToolbar)**(string toolBarId)|
-|void |**[convertActions](#convertActions)**(int flags)|
-||**[convertAssets](#convertAssets)**(int flags)|
+|void |**[convertActions](#convertActions)**(ConversionFlags flags)|
+||**[convertAssets](#convertAssets)**(ConversionFlags flags)|
 |string |**[convertLanguageToCode](#convertLanguageToCode)**(string language)|
-|[Widget](../knut/widget.md) |**[dialog](#dialog)**(string id, int flags, real scaleX, real scaleY)|
+|[Widget](../knut/widget.md) |**[dialog](#dialog)**(string id, ConversionFlags flags, real scaleX, real scaleY)|
 |string |**[dialogTitleForLanguage](#dialogTitleForLanguage)**(string language, string dialogId)|
 |[Menu](../knut/menu.md) |**[menu](#menu)**(string id)|
 |bool |**[mergeAllLanguages](#mergeAllLanguages)**(string language = "[default]")|
@@ -51,7 +51,7 @@ import Knut
 |string |**[stringForLanguage](#stringForLanguage)**(string language, string id)|
 |array&lt;[String](../knut/string.md)> |**[stringsForLanguage](#stringsForLanguage)**(string language)|
 |[ToolBar](../knut/toolbar.md) |**[toolBar](#toolBar)**(string id)|
-|bool |**[writeAssetsToImage](#writeAssetsToImage)**(int flags)|
+|bool |**[writeAssetsToImage](#writeAssetsToImage)**(ConversionFlags flags)|
 |bool |**[writeAssetsToQrc](#writeAssetsToQrc)**(string fileName)|
 |bool |**[writeDialogToUi](#writeDialogToUi)**([Widget](../knut/widget.md) dialog, string fileName)|
 
@@ -138,7 +138,7 @@ Returns all actions used in the menu `menuId` for language `language`.
 
 Returns all actions used in the toolbar `toolBarId`.
 
-#### <a name="convertActions"></a>void **convertActions**(int flags)
+#### <a name="convertActions"></a>void **convertActions**(ConversionFlags flags)
 
 
 !!! Warning "Experimental API"
@@ -153,7 +153,7 @@ The `flags` are used to fill the iconPath of the action:
 - `RcDocument.ConvertToPng`: convert BMPs to PNGs, needed if we want to also change the transparency
 - `RcDocument.AllFlags`: combination of all above
 
-#### <a name="convertAssets"></a>**convertAssets**(int flags)
+#### <a name="convertAssets"></a>**convertAssets**(ConversionFlags flags)
 
 Converts all assets using the `flags`.
 
@@ -166,7 +166,7 @@ Converts all assets using the `flags`.
 
 Returns language code as defined by the ISO 639 for language name
 
-#### <a name="dialog"></a>[Widget](../knut/widget.md) **dialog**(string id, int flags, real scaleX, real scaleY)
+#### <a name="dialog"></a>[Widget](../knut/widget.md) **dialog**(string id, ConversionFlags flags, real scaleX, real scaleY)
 
 Returns the dialog for the given `id`.
 
@@ -235,7 +235,7 @@ Returns translated string for specific `language`.
 
 Returns the toolbar for the given `id`.
 
-#### <a name="writeAssetsToImage"></a>bool **writeAssetsToImage**(int flags)
+#### <a name="writeAssetsToImage"></a>bool **writeAssetsToImage**(ConversionFlags flags)
 
 Writes the assets to images, using `flags` for transparency settings. Returns `true` if no issues.
 

--- a/docs/API/knut/textdocument.md
+++ b/docs/API/knut/textdocument.md
@@ -44,8 +44,8 @@ Inherited properties: [Document properties](../knut/document.md#properties)
 ||**[deleteSelection](#deleteSelection)**()|
 ||**[deleteStartOfLine](#deleteStartOfLine)**()|
 ||**[deleteStartOfWord](#deleteStartOfWord)**()|
-|bool |**[find](#find)**(string text, int options = TextDocument.NoFindFlags)|
-|bool |**[findRegexp](#findRegexp)**(string regexp, int options = TextDocument.NoFindFlags)|
+|bool |**[find](#find)**(string text, FindFlags options = TextDocument.NoFindFlags)|
+|bool |**[findRegexp](#findRegexp)**(string regexp, FindFlags options = TextDocument.NoFindFlags)|
 ||**[gotoEndOfDocument](#gotoEndOfDocument)**()|
 ||**[gotoEndOfLine](#gotoEndOfLine)**()|
 ||**[gotoEndOfWord](#gotoEndOfWord)**()|
@@ -67,7 +67,7 @@ Inherited properties: [Document properties](../knut/document.md#properties)
 ||**[insertAtLine](#insertAtLine)**(string text, int line = -1)|
 ||**[insertAtPosition](#insertAtPosition)**(string text, int pos)|
 ||**[lineAtPosition](#lineAtPosition)**(int position)|
-|bool |**[match](#match)**(string regexp, int options = TextDocument.NoFindFlags)|
+|bool |**[match](#match)**(string regexp, FindFlags options = TextDocument.NoFindFlags)|
 ||**[paste](#paste)**()|
 ||**[positionAt](#positionAt)**(int line, int col)|
 ||**[redo](#redo)**(int count)|
@@ -76,11 +76,11 @@ Inherited properties: [Document properties](../knut/document.md#properties)
 ||**[replace](#replace)**(int length, string text)|
 ||**[replace](#replace)**([RangeMark](../knut/rangemark.md) range, string text)|
 ||**[replace](#replace)**(int from, int to, string text)|
-|bool |**[replaceAll](#replaceAll)**(string before, string after, int options = TextDocument.NoFindFlags)|
-|bool |**[replaceAllInRange](#replaceAllInRange)**(string before, string after, [RangeMark](../knut/rangemark.md) range, int options = TextDocument.NoFindFlags)|
-|bool |**[replaceAllRegexp](#replaceAllRegexp)**(string regexp, string after, int options = TextDocument.NoFindFlags)|
-|bool |**[replaceAllRegexpInRange](#replaceAllRegexpInRange)**(string regexp, string after, [RangeMark](../knut/rangemark.md) range, int options = TextDocument.NoFindFlags)|
-|bool |**[replaceOne](#replaceOne)**(string before, string after, int options = TextDocument.NoFindFlags)|
+|bool |**[replaceAll](#replaceAll)**(string before, string after, FindFlags options = TextDocument.NoFindFlags)|
+|bool |**[replaceAllInRange](#replaceAllInRange)**(string before, string after, [RangeMark](../knut/rangemark.md) range, FindFlags options = TextDocument.NoFindFlags)|
+|bool |**[replaceAllRegexp](#replaceAllRegexp)**(string regexp, string after, FindFlags options = TextDocument.NoFindFlags)|
+|bool |**[replaceAllRegexpInRange](#replaceAllRegexpInRange)**(string regexp, string after, [RangeMark](../knut/rangemark.md) range, FindFlags options = TextDocument.NoFindFlags)|
+|bool |**[replaceOne](#replaceOne)**(string before, string after, FindFlags options = TextDocument.NoFindFlags)|
 ||**[selectAll](#selectAll)**()|
 ||**[selectEndOfLine](#selectEndOfLine)**()|
 ||**[selectEndOfWord](#selectEndOfWord)**()|
@@ -224,7 +224,7 @@ Deletes from the cursor position to the start of the line.
 
 Deletes from the cursor position to the start of the word.
 
-#### <a name="find"></a>bool **find**(string text, int options = TextDocument.NoFindFlags)
+#### <a name="find"></a>bool **find**(string text, FindFlags options = TextDocument.NoFindFlags)
 
 Searches the string `text` in the editor. Options could be a combination of:
 
@@ -235,7 +235,7 @@ Searches the string `text` in the editor. Options could be a combination of:
 
 Selects the match and returns `true` if a match is found.
 
-#### <a name="findRegexp"></a>bool **findRegexp**(string regexp, int options = TextDocument.NoFindFlags)
+#### <a name="findRegexp"></a>bool **findRegexp**(string regexp, FindFlags options = TextDocument.NoFindFlags)
 
 Searches the string `regexp` in the editor using a regular expression. Options could be a combination of:
 
@@ -329,7 +329,7 @@ Inserts the string `text` at `pos`.
 
 Returns the line number for the given text cursor `position`. Or -1 if position is invalid
 
-#### <a name="match"></a>bool **match**(string regexp, int options = TextDocument.NoFindFlags)
+#### <a name="match"></a>bool **match**(string regexp, FindFlags options = TextDocument.NoFindFlags)
 
 Searches the string `regexp` in the editor using a regular expression. Options could be a combination of:
 
@@ -371,7 +371,7 @@ Replaces the text in the range `range` with the string `text`.
 
 Replaces the text from `from` to `to` with the string `text`.
 
-#### <a name="replaceAll"></a>bool **replaceAll**(string before, string after, int options = TextDocument.NoFindFlags)
+#### <a name="replaceAll"></a>bool **replaceAll**(string before, string after, FindFlags options = TextDocument.NoFindFlags)
 
 Replaces all occurrences of the string `before` with `after`. Options could be a combination of:
 
@@ -391,22 +391,23 @@ the occurrence only.
 
 Returns the number of changes done in the document.
 
-#### <a name="replaceAllInRange"></a>bool **replaceAllInRange**(string before, string after, [RangeMark](../knut/rangemark.md) range, int options = TextDocument.NoFindFlags)
+#### <a name="replaceAllInRange"></a>bool **replaceAllInRange**(string before, string after, [RangeMark](../knut/rangemark.md) range, FindFlags options = TextDocument.NoFindFlags)
 
 Replaces all occurrences of the string `before` with `after` in the given `range`. See the
 options from `replaceAll`.
 
 Returns the number of changes done in the document.
 
-#### <a name="replaceAllRegexp"></a>bool **replaceAllRegexp**(string regexp, string after, int options = TextDocument.NoFindFlags)
+#### <a name="replaceAllRegexp"></a>bool **replaceAllRegexp**(string regexp, string after, FindFlags options = TextDocument.NoFindFlags)
 
-Replaces all occurrences of the matches for the `regexp` with `after`. See the options from `replaceAll`.
+Replaces all occurrences of the matches for the `regexp` with `after`. See the options from
+`replaceAll`.
 
 The captures coming from the regexp can be used in the replacement text, using `\1`..`\n` or `$1`..`$n`.
 
 Returns the number of changes done in the document.
 
-#### <a name="replaceAllRegexpInRange"></a>bool **replaceAllRegexpInRange**(string regexp, string after, [RangeMark](../knut/rangemark.md) range, int options = TextDocument.NoFindFlags)
+#### <a name="replaceAllRegexpInRange"></a>bool **replaceAllRegexpInRange**(string regexp, string after, [RangeMark](../knut/rangemark.md) range, FindFlags options = TextDocument.NoFindFlags)
 
 Replaces all occurrences of the matches for the `regexp` with `after` in the given `range`. See the options from `replaceAll`.
 
@@ -414,7 +415,7 @@ The captures coming from the regexp can be used in the replacement text, using `
 
 Returns the number of changes done in the document.
 
-#### <a name="replaceOne"></a>bool **replaceOne**(string before, string after, int options = TextDocument.NoFindFlags)
+#### <a name="replaceOne"></a>bool **replaceOne**(string before, string after, FindFlags options = TextDocument.NoFindFlags)
 
 Replaces one occurrence of the string `before` with `after`. Options could be a combination of:
 

--- a/src/core/rcdocument.cpp
+++ b/src/core/rcdocument.cpp
@@ -258,7 +258,7 @@ RcCore::ToolBar RcDocument::toolBar(const QString &id) const
 }
 
 /*!
- * \qmlmethod Widget RcDocument::dialog(string id, int flags, real scaleX, real scaleY)
+ * \qmlmethod Widget RcDocument::dialog(string id, ConversionFlags flags, real scaleX, real scaleY)
  * \sa RcDocument::writeDialogToUi
  * Returns the dialog for the given `id`.
  *
@@ -272,17 +272,17 @@ RcCore::ToolBar RcDocument::toolBar(const QString &id) const
  * - `RcDocument.UseIdForPixmap`: use the id as a resource value for the pixmaps in labels
  * - `RcDocument.AllFlags`: combination of all above
  */
-RcCore::Widget RcDocument::dialog(const QString &id, int flags, double scaleX, double scaleY) const
+RcCore::Widget RcDocument::dialog(const QString &id, ConversionFlags flags, double scaleX, double scaleY) const
 {
     LOG(id, flags, scaleX, scaleY);
 
-    SET_DEFAULT_VALUE(RcDialogFlags, static_cast<ConversionFlags>(flags));
+    SET_DEFAULT_VALUE(RcDialogFlags, flags);
     SET_DEFAULT_VALUE(RcDialogScaleX, scaleX);
     SET_DEFAULT_VALUE(RcDialogScaleY, scaleY);
     if (isDataValid()) {
         if (auto dialog = data().dialog(id))
-            return RcCore::convertDialog(data(), *dialog, static_cast<RcCore::Widget::ConversionFlags>(flags), scaleX,
-                                         scaleY);
+            return RcCore::convertDialog(
+                data(), *dialog, static_cast<RcCore::Widget::ConversionFlags>(static_cast<int>(flags)), scaleX, scaleY);
     }
     return {};
 }
@@ -597,7 +597,7 @@ QList<RcCore::Menu> RcDocument::menus() const
 }
 
 /*!
- * \qmlmethod RcDocument::convertAssets(int flags)
+ * \qmlmethod RcDocument::convertAssets(ConversionFlags flags)
  * \sa RcDocument::writeAssetsToImage
  * \sa RcDocument::writeAssetsToQrc
  *
@@ -608,19 +608,20 @@ QList<RcCore::Menu> RcDocument::menus() const
  * - `RcDocument.ConvertToPng`: convert BMPs to PNGs, needed if we want to also change the transparency
  * - `RcDocument.AllFlags`: combination of all above
  */
-void RcDocument::convertAssets(int flags)
+void RcDocument::convertAssets(ConversionFlags flags)
 {
     LOG(flags);
 
-    SET_DEFAULT_VALUE(RcAssetFlags, static_cast<ConversionFlags>(flags));
+    SET_DEFAULT_VALUE(RcAssetFlags, flags);
     if (isDataValid()) {
-        m_cacheAssets = RcCore::convertAssets(data(), static_cast<RcCore::Asset::ConversionFlags>(flags));
+        m_cacheAssets =
+            RcCore::convertAssets(data(), static_cast<RcCore::Asset::ConversionFlags>(static_cast<int>(flags)));
         emit fileNameChanged();
     }
 }
 
 /*!
- * \qmlmethod void RcDocument::convertActions(int flags)
+ * \qmlmethod void RcDocument::convertActions(ConversionFlags flags)
  * \todo
  * Converts all actions using the `flags`.
  *
@@ -631,19 +632,20 @@ void RcDocument::convertAssets(int flags)
  * - `RcDocument.ConvertToPng`: convert BMPs to PNGs, needed if we want to also change the transparency
  * - `RcDocument.AllFlags`: combination of all above
  */
-void RcDocument::convertActions(int flags)
+void RcDocument::convertActions(ConversionFlags flags)
 {
     LOG(flags);
 
-    SET_DEFAULT_VALUE(RcAssetFlags, static_cast<ConversionFlags>(flags));
+    SET_DEFAULT_VALUE(RcAssetFlags, flags);
     if (isDataValid()) {
-        m_cacheActions = RcCore::convertActions(data(), static_cast<RcCore::Asset::ConversionFlags>(flags));
+        m_cacheActions =
+            RcCore::convertActions(data(), static_cast<RcCore::Asset::ConversionFlags>(static_cast<int>(flags)));
         emit fileNameChanged();
     }
 }
 
 /*!
- * \qmlmethod bool RcDocument::writeAssetsToImage(int flags)
+ * \qmlmethod bool RcDocument::writeAssetsToImage(ConversionFlags flags)
  * \sa RcDocument::convertAssets
  * Writes the assets to images, using `flags` for transparency settings. Returns `true` if no issues.
  *
@@ -657,14 +659,14 @@ void RcDocument::convertActions(int flags)
  * - `RcDocument.BottomLeftPixel`: the color of the bottom left pixel is used as transparent
  * - `RcDocument.AllColors`: combination of all above
  */
-bool RcDocument::writeAssetsToImage(int flags)
+bool RcDocument::writeAssetsToImage(ConversionFlags flags)
 {
     LOG(flags);
 
-    SET_DEFAULT_VALUE(RcAssetColors, static_cast<ConversionFlags>(flags));
+    SET_DEFAULT_VALUE(RcAssetColors, flags);
     if (m_cacheAssets.isEmpty())
         convertAssets();
-    RcCore::writeAssetsToImage(m_cacheAssets, static_cast<RcCore::Asset::TransparentColors>(flags));
+    RcCore::writeAssetsToImage(m_cacheAssets, static_cast<RcCore::Asset::TransparentColors>(static_cast<int>(flags)));
     return true;
 }
 

--- a/src/core/rcdocument.h
+++ b/src/core/rcdocument.h
@@ -73,9 +73,10 @@ public:
     QList<RcCore::ToolBar> toolBars() const;
     Q_INVOKABLE RcCore::ToolBar toolBar(const QString &id) const;
 
-    Q_INVOKABLE RcCore::Widget dialog(const QString &id, int flags = DEFAULT_VALUE(ConversionFlags, RcDialogFlags),
-                                      double scaleX = DEFAULT_VALUE(double, RcDialogScaleX),
-                                      double scaleY = DEFAULT_VALUE(double, RcDialogScaleY)) const;
+    Q_INVOKABLE RcCore::Widget
+    dialog(const QString &id, Core::RcDocument::ConversionFlags flags = DEFAULT_VALUE(ConversionFlags, RcDialogFlags),
+           double scaleX = DEFAULT_VALUE(double, RcDialogScaleX),
+           double scaleY = DEFAULT_VALUE(double, RcDialogScaleY)) const;
 
     QList<RcCore::Menu> menus() const;
     Q_INVOKABLE RcCore::Menu menu(const QString &id) const;
@@ -109,9 +110,9 @@ public:
     const RcCore::RcFile &file() const;
 
 public slots:
-    void convertAssets(int flags = DEFAULT_VALUE(ConversionFlag, RcAssetFlags));
-    void convertActions(int flags = DEFAULT_VALUE(ConversionFlags, RcAssetFlags));
-    bool writeAssetsToImage(int flags = DEFAULT_VALUE(ConversionFlags, RcAssetColors));
+    void convertAssets(Core::RcDocument::ConversionFlags flags = DEFAULT_VALUE(ConversionFlag, RcAssetFlags));
+    void convertActions(Core::RcDocument::ConversionFlags flags = DEFAULT_VALUE(ConversionFlags, RcAssetFlags));
+    bool writeAssetsToImage(Core::RcDocument::ConversionFlags flags = DEFAULT_VALUE(ConversionFlags, RcAssetColors));
     bool writeAssetsToQrc(const QString &fileName);
     bool writeDialogToUi(const RcCore::Widget &dialog, const QString &fileName);
     void previewDialog(const RcCore::Widget &dialog) const;

--- a/src/core/textdocument.cpp
+++ b/src/core/textdocument.cpp
@@ -1190,7 +1190,7 @@ Core::RangeMark TextDocument::createRangeMark()
 }
 
 /*!
- * \qmlmethod bool TextDocument::find(string text, int options = TextDocument.NoFindFlags)
+ * \qmlmethod bool TextDocument::find(string text, FindFlags options = TextDocument.NoFindFlags)
  * Searches the string `text` in the editor. Options could be a combination of:
  *
  * - `TextDocument.FindBackward`: search backward
@@ -1200,7 +1200,7 @@ Core::RangeMark TextDocument::createRangeMark()
  *
  * Selects the match and returns `true` if a match is found.
  */
-bool TextDocument::find(const QString &text, int options)
+bool TextDocument::find(const QString &text, FindFlags options)
 {
     LOG(LOG_ARG("text", text), options);
     if (options & FindRegexp)
@@ -1208,11 +1208,11 @@ bool TextDocument::find(const QString &text, int options)
     else if (options & FindWholeWords)
         return findRegexp(QRegularExpression::escape(text), options);
     else
-        return m_document->find(text, static_cast<QTextDocument::FindFlags>(options));
+        return m_document->find(text, static_cast<QTextDocument::FindFlags>(static_cast<int>(options)));
 }
 
 /*!
- * \qmlmethod bool TextDocument::findRegexp(string regexp, int options = TextDocument.NoFindFlags)
+ * \qmlmethod bool TextDocument::findRegexp(string regexp, FindFlags options = TextDocument.NoFindFlags)
  * Searches the string `regexp` in the editor using a regular expression. Options could be a combination of:
  *
  * - `TextDocument.FindBackward`: search backward
@@ -1221,7 +1221,7 @@ bool TextDocument::find(const QString &text, int options)
  *
  * Selects the match and returns `true` if a match is found.
  */
-bool TextDocument::findRegexp(const QString &regexp, int options)
+bool TextDocument::findRegexp(const QString &regexp, FindFlags options)
 {
     LOG(LOG_ARG("text", regexp), options);
 
@@ -1281,7 +1281,7 @@ auto TextDocument::selectRegexpMatch(
 }
 
 /*!
- * \qmlmethod bool TextDocument::match(string regexp, int options = TextDocument.NoFindFlags)
+ * \qmlmethod bool TextDocument::match(string regexp, FindFlags options = TextDocument.NoFindFlags)
  * Searches the string `regexp` in the editor using a regular expression. Options could be a combination of:
  *
  * - `TextDocument.FindBackward`: search backward
@@ -1290,7 +1290,7 @@ auto TextDocument::selectRegexpMatch(
  *
  * Selects the match and returns the named group if a match is found.
  */
-QString TextDocument::match(const QString &regexp, int options)
+QString TextDocument::match(const QString &regexp, FindFlags options)
 {
     LOG(regexp, options);
 
@@ -1311,7 +1311,7 @@ QString TextDocument::match(const QString &regexp, int options)
 }
 
 /*!
- * \qmlmethod bool TextDocument::replaceOne(string before, string after, int options = TextDocument.NoFindFlags)
+ * \qmlmethod bool TextDocument::replaceOne(string before, string after, FindFlags options = TextDocument.NoFindFlags)
  * Replaces one occurrence of the string `before` with `after`. Options could be a combination of:
  *
  * - `TextDocument.FindCaseSensitively`: match case
@@ -1330,7 +1330,7 @@ QString TextDocument::match(const QString &regexp, int options)
  *
  * Returns true if a change occurs in the document..
  */
-bool TextDocument::replaceOne(const QString &before, const QString &after, int options)
+bool TextDocument::replaceOne(const QString &before, const QString &after, FindFlags options)
 {
     LOG(LOG_ARG("text", before), after, options);
 
@@ -1363,7 +1363,7 @@ bool TextDocument::replaceOne(const QString &before, const QString &after, int o
 }
 
 /*!
- * \qmlmethod bool TextDocument::replaceAll(string before, string after, int options = TextDocument.NoFindFlags)
+ * \qmlmethod bool TextDocument::replaceAll(string before, string after, FindFlags options = TextDocument.NoFindFlags)
  * Replaces all occurrences of the string `before` with `after`. Options could be a combination of:
  *
  * - `TextDocument.FindCaseSensitively`: match case
@@ -1382,7 +1382,7 @@ bool TextDocument::replaceOne(const QString &before, const QString &after, int o
  *
  * Returns the number of changes done in the document.
  */
-int TextDocument::replaceAll(const QString &before, const QString &after, int options /* = NoFindFlags */)
+int TextDocument::replaceAll(const QString &before, const QString &after, FindFlags options /* = NoFindFlags */)
 {
     LOG(LOG_ARG("text", before), after, options);
     return replaceAll(before, after, options, [](auto) {
@@ -1392,7 +1392,7 @@ int TextDocument::replaceAll(const QString &before, const QString &after, int op
 
 // clang-format off
 /*!
- * \qmlmethod bool TextDocument::replaceAllInRange(string before, string after, RangeMark range, int options = TextDocument.NoFindFlags)
+ * \qmlmethod bool TextDocument::replaceAllInRange(string before, string after, RangeMark range, FindFlags options = TextDocument.NoFindFlags)
  * Replaces all occurrences of the string `before` with `after` in the given `range`. See the
  * options from `replaceAll`.
  *
@@ -1400,7 +1400,7 @@ int TextDocument::replaceAll(const QString &before, const QString &after, int op
  */
 // clang-format on
 int TextDocument::replaceAllInRange(const QString &before, const QString &after, const Core::RangeMark &range,
-                                    int options)
+                                    FindFlags options)
 {
     LOG(LOG_ARG("text", before), after, range, options);
     if (!range.isValid()) {
@@ -1419,7 +1419,7 @@ int TextDocument::replaceAllInRange(const QString &before, const QString &after,
     });
 }
 
-int TextDocument::replaceAll(const QString &before, const QString &after, int options,
+int TextDocument::replaceAll(const QString &before, const QString &after, FindFlags options,
                              const std::function<bool(QTextCursor)> &filterAcceptsCursor)
 {
     const bool backwards = options & FindBackward;
@@ -1456,15 +1456,18 @@ int TextDocument::replaceAll(const QString &before, const QString &after, int op
     return count;
 }
 
+// clang-format off
 /*!
- * \qmlmethod bool TextDocument::replaceAllRegexp(string regexp, string after, int options = TextDocument.NoFindFlags)
- * Replaces all occurrences of the matches for the `regexp` with `after`. See the options from `replaceAll`.
+ * \qmlmethod bool TextDocument::replaceAllRegexp(string regexp, string after, FindFlags options = TextDocument.NoFindFlags)
+ * Replaces all occurrences of the matches for the `regexp` with `after`. See the options from
+ * `replaceAll`.
  *
  * The captures coming from the regexp can be used in the replacement text, using `\1`..`\n` or `$1`..`$n`.
  *
  * Returns the number of changes done in the document.
  */
-int TextDocument::replaceAllRegexp(const QString &regexp, const QString &after, int options /* = NoFindFlags */)
+// clang-format on
+int TextDocument::replaceAllRegexp(const QString &regexp, const QString &after, FindFlags options /* = NoFindFlags */)
 {
     LOG(LOG_ARG("text", regexp), after, options);
     return replaceAllRegexp(regexp, after, options, [](auto) {
@@ -1474,7 +1477,7 @@ int TextDocument::replaceAllRegexp(const QString &regexp, const QString &after, 
 
 // clang-format off
 /*!
- * \qmlmethod bool TextDocument::replaceAllRegexpInRange(string regexp, string after, RangeMark range, int options = TextDocument.NoFindFlags)
+ * \qmlmethod bool TextDocument::replaceAllRegexpInRange(string regexp, string after, RangeMark range, FindFlags options = TextDocument.NoFindFlags)
  * Replaces all occurrences of the matches for the `regexp` with `after` in the given `range`. See the options from `replaceAll`.
  *
  * The captures coming from the regexp can be used in the replacement text, using `\1`..`\n` or `$1`..`$n`.
@@ -1483,7 +1486,7 @@ int TextDocument::replaceAllRegexp(const QString &regexp, const QString &after, 
  */
 // clang-format on
 int TextDocument::replaceAllRegexpInRange(const QString &regexp, const QString &after, const RangeMark &range,
-                                          int options /* = NoFindFlags*/)
+                                          FindFlags options /* = NoFindFlags*/)
 {
     LOG(LOG_ARG("text", regexp), after, range, options);
     if (!range.isValid()) {
@@ -1502,7 +1505,7 @@ int TextDocument::replaceAllRegexpInRange(const QString &regexp, const QString &
     });
 }
 
-int TextDocument::replaceAllRegexp(const QString &regexp, const QString &after, int options,
+int TextDocument::replaceAllRegexp(const QString &regexp, const QString &after, FindFlags options,
                                    const std::function<bool(QTextCursor)> &filterAcceptsCursor)
 {
     return replaceAll(regexp, after, options | FindRegexp, filterAcceptsCursor);

--- a/src/core/textdocument.h
+++ b/src/core/textdocument.h
@@ -170,21 +170,22 @@ public slots:
     Core::RangeMark createRangeMark();
 
     // Find
-    bool find(const QString &text, int options = NoFindFlags);
-    bool findRegexp(const QString &regexp, int options = NoFindFlags);
-    QString match(const QString &regexp, int options = NoFindFlags);
+    bool find(const QString &text, Core::TextDocument::FindFlags options = NoFindFlags);
+    bool findRegexp(const QString &regexp, Core::TextDocument::FindFlags options = NoFindFlags);
+    QString match(const QString &regexp, Core::TextDocument::FindFlags options = NoFindFlags);
 
     // Replace
     void replace(int length, const QString &text);
     void replace(int from, int to, const QString &text);
     void replace(const Core::RangeMark &range, const QString &text);
-    bool replaceOne(const QString &before, const QString &after, int options = NoFindFlags);
-    int replaceAll(const QString &before, const QString &after, int options = NoFindFlags);
+    bool replaceOne(const QString &before, const QString &after, Core::TextDocument::FindFlags options = NoFindFlags);
+    int replaceAll(const QString &before, const QString &after, Core::TextDocument::FindFlags options = NoFindFlags);
     int replaceAllInRange(const QString &before, const QString &after, const Core::RangeMark &range,
-                          int options = NoFindFlags);
+                          Core::TextDocument::FindFlags options = NoFindFlags);
     int replaceAllRegexpInRange(const QString &regexp, const QString &after, const Core::RangeMark &range,
-                                int options = NoFindFlags);
-    int replaceAllRegexp(const QString &regexp, const QString &after, int options = NoFindFlags);
+                                Core::TextDocument::FindFlags options = NoFindFlags);
+    int replaceAllRegexp(const QString &regexp, const QString &after,
+                         Core::TextDocument::FindFlags options = NoFindFlags);
 
     // Indentation
     void indent(int count = 1);
@@ -207,9 +208,9 @@ protected:
     void convertPosition(int pos, int *line, int *column) const;
     int position(QTextCursor::MoveOperation operation, int pos) const;
 
-    int replaceAll(const QString &before, const QString &after, int options,
+    int replaceAll(const QString &before, const QString &after, FindFlags options,
                    const std::function<bool(QTextCursor)> &filterAcceptsCursor);
-    int replaceAllRegexp(const QString &regexp, const QString &after, int options,
+    int replaceAllRegexp(const QString &regexp, const QString &after, FindFlags options,
                          const std::function<bool(QTextCursor)> &filterAcceptsCursor);
 
 private:

--- a/src/gui/textview.cpp
+++ b/src/gui/textview.cpp
@@ -170,16 +170,16 @@ bool TextView::eventFilter(QObject *obj, QEvent *event)
 
 void TextView::find(const QString &text, int options)
 {
-    document()->find(text, options);
+    document()->find(text, static_cast<Core::TextDocument::FindFlags>(options));
 }
 
 void TextView::replace(const QString &before, const QString &after, int options, bool replaceAll)
 {
     if (replaceAll) {
-        document()->replaceAll(before, after, options);
+        document()->replaceAll(before, after, static_cast<Core::TextDocument::FindFlags>(options));
 
     } else {
-        document()->replaceOne(before, after, options);
+        document()->replaceOne(before, after, static_cast<Core::TextDocument::FindFlags>(options));
     }
 }
 


### PR DESCRIPTION
This makes it easier for a human to read and edit the script after the fact.
Mostly useful for the find API in TextDocument

Fix #177