### PR TITLE
fix: Don't log anything on hover

### DIFF
--- a/src/core/lsp_utils.cpp
+++ b/src/core/lsp_utils.cpp
@@ -10,6 +10,7 @@
 
 #include "lsp_utils.h"
 #include "codedocument.h"
+#include "logger.h"
 #include "project.h"
 #include "textdocument.h"
 
@@ -46,6 +47,7 @@ int lspToPos(const TextDocument &textDocument, const Lsp::Position &pos)
 
 RangeMark lspToRange(const TextDocument &textDocument, const Lsp::Range &range)
 {
+    LoggerDisabler disabler;
     // I know, ugly, but that's the easiest to do that here.
     auto document = const_cast<TextDocument *>(&textDocument);
     return document->createRangeMark(lspToPos(textDocument, range.start), lspToPos(textDocument, range.end));


### PR DESCRIPTION
Otherwise, there's a createRangeMark method logged when showing lsp
documentation for the symbol.