### PR TITLE
ci: add submodule-bump.yml

### DIFF
--- a/.github/workflows/submodule-bump.yml
+++ b/.github/workflows/submodule-bump.yml
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: 2024 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+#
+# SPDX-License-Identifier: MIT
+
+on:
+  workflow_dispatch:
+    inputs:
+      submodule:
+        type: choice
+        description: "Select an option"
+        options:
+          - "Only print current and available versions"
+          - spdlog
+          - extra_cmake_modules
+          - kdalgorithms
+          - ksyntaxhighlighting
+          - nlohmann_json
+          - pugixml
+          - tree_sitter
+          - tree_sitter_cpp
+          - tree_sitter_qmljs
+
+name: bump submodules
+jobs:
+  dependency-bump:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+        with:
+          submodules: false
+
+      - name: Checkout submodules
+        run: |
+          git submodule update --init --force --recursive -- 3rdparty/*
+          git clone https://github.com/KDABLabs/ci-release-tools.git
+
+      - name: Configure Git committer
+        run: |
+          git config --global user.name "KDAB GitHub Actions"
+          git config --global user.email "gh@kdab"
+
+      - name: Print current and available versions
+        if: inputs.submodule == 'Only print current and available versions'
+        run: |
+          python3 ./ci-release-tools/src/update_dependencies.py --print-dependency-versions --proj-name Knut --repo-path .
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Bump submodule
+        if: inputs.submodule != 'Only print current and available versions'
+        run: |
+          python3 ./ci-release-tools/src/update_dependencies.py --update-dependency ${{inputs.submodule}} --proj-name Knut --repo-path .
+        env:
+          GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
Allows to print the overall current versions and latest versions of all submodules.

Also allows to update submodules to their latest version.

The maintainer needs to manually trigger this workflow, it won't be scheduled.