### PR TITLE
feat: Add basic support for C# documents

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -32,3 +32,6 @@
 [submodule "3rdparty/photonwidgets"]
 	path = 3rdparty-kdab/photonwidgets
 	url = ssh://codereview.kdab.com:29418/photonwidgets
+[submodule "3rdparty/tree-sitter-c-sharp"]
+	path = 3rdparty/tree-sitter-c-sharp
+	url = https://github.com/tree-sitter/tree-sitter-c-sharp.git

--- a/3rdparty/CMakeLists.txt
+++ b/3rdparty/CMakeLists.txt
@@ -99,3 +99,15 @@ target_link_libraries(${PROJECT_NAME} PRIVATE TreeSitter)
 # Always build tree-sitter with optimizations enabled. We shouldn't have to
 # debug it and it's performance critical.
 enable_optimizations(${PROJECT_NAME})
+
+# TreeSitterCSharp
+# ##############################################################################
+check_submodule(tree-sitter tree-sitter-c-sharp)
+project(TreeSitterCSharp LANGUAGES C)
+
+add_library(${PROJECT_NAME} STATIC tree-sitter-c-sharp/src/parser.c
+                                   tree-sitter-c-sharp/src/scanner.c)
+target_link_libraries(${PROJECT_NAME} PRIVATE TreeSitter)
+# Always build tree-sitter with optimizations enabled. We shouldn't have to
+# debug it and it's performance critical.
+enable_optimizations(${PROJECT_NAME})

--- a/README.md
+++ b/README.md
@@ -11,6 +11,36 @@ The script API is available in this documentation, and ranges from normal text t
 
 Knut can be used via a command line interface or a user interface.
 
+## Supported programming languages
+
+Knut supports multiple programming languages and file types to different degrees.
+
+This table provides a basic overview of the current support.
+Please refer to the subclasses of [Document](https://kdab.github.io/knut/API/knut/document.html) for details on the supported functions of each class.
+
+<!-- NOTE: SYNC WITH docs/index.md! -->
+|                            | 🌳 TreeSitter | 🔣 Code Items | 🧑‍💻 LSP | 🖥️ File Viewer |
+|----------------------------|---------------|---------------|---------|---------------|
+| C/C++                      | ✅            | ✅            | ✅      |               |
+| C#                         | ✅            | ❌            | ❌      |               |
+| JSON                       | ❌            | ✔️             | ❌      |               |
+| [Qt Translate (.ts)][QtTs] | ❌            | ✔️             | ❌      |               |
+| [Qt Qml][Qml]              | ✅            | ✅            | ❌      | ✅             |
+| [Qt Ui files][QtUi]        | ❌            | ❌            | ❌      | ✅             |
+| [Slint][Slint]             | ❌            | ❌            | ❌      | ✅             |
+| [MFC rc files][MfcRc]      | ❌            | ✔️             | ❌      | ✔️             |
+
+> ✅ Fully Supported
+> ✔️  Partial Support
+> ❌ Unsupported
+
+[QtTs]: https://doc.qt.io/qt-6/linguist-ts-file-format.html
+[QtUi]: https://doc.qt.io/qt-6/designer-ui-file-format.html
+[Qml]: https://doc.qt.io/qt-6/qmlreference.html
+[Slint]: https://slint.dev/
+[MfcRc]: https://learn.microsoft.com/en-us/windows/win32/menurc/about-resource-files
+
+
 ## Requirements
 
 Knut is using [Language Server Protocol](https://microsoft.github.io/language-server-protocol/) servers for the GUI. It is not used for the scripts, so if you are using Knut with the command line interface, you don't need it.

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,9 +3,38 @@
 Knut is an automation tool for code transformation using scripts. The main use case is for migration, but it could be used elsewhere.
 
 The scripts are written either in javascript or QML languages, the latter being able to display a user interface to customize some parts of the application.
-The script API is available in this documentation, and ranges from normal text transformations (find and replace) to getting contextual information based on the file language (using [TreeSitter](https://tree-sitter.github.io/tree-sitter/).
+The script API is available in this documentation, and ranges from normal text transformations (find and replace) to getting contextual information based on the file language (using [TreeSitter](https://tree-sitter.github.io/tree-sitter/)).
 
 Knut can be used via a command line interface or a user interface.
+
+## Supported programming languages
+
+Knut supports multiple programming languages and file types to different degrees.
+
+This table provides a basic overview of the current support.
+Please refer to the subclasses of [Document](https://kdab.github.io/knut/API/knut/document.html) for details on the supported functions of each class.
+
+<!-- NOTE: SYNC WITH README.md! -->
+|                            | 🌳 TreeSitter | 🔣 Code Items | 🧑‍💻 LSP | 🖥️ File Viewer |
+|----------------------------|---------------|---------------|---------|---------------|
+| C/C++                      | ✅            | ✅            | ✅      |               |
+| C#                         | ✅            | ❌            | ❌      |               |
+| JSON                       | ❌            | ✔️             | ❌      |               |
+| [Qt Translate (.ts)][QtTs] | ❌            | ✔️             | ❌      |               |
+| [Qt Qml][Qml]              | ✅            | ✅            | ❌      | ✅             |
+| [Qt Ui files][QtUi]        | ❌            | ❌            | ❌      | ✅             |
+| [Slint][Slint]             | ❌            | ❌            | ❌      | ✅             |
+| [MFC rc files][MfcRc]      | ❌            | ✔️             | ❌      | ✔️             |
+
+> ✅ Fully Supported
+> ✔️  Partial Support
+> ❌ Unsupported
+
+[QtTs]: https://doc.qt.io/qt-6/linguist-ts-file-format.html
+[QtUi]: https://doc.qt.io/qt-6/designer-ui-file-format.html
+[Qml]: https://doc.qt.io/qt-6/qmlreference.html
+[Slint]: https://slint.dev/
+[MfcRc]: https://learn.microsoft.com/en-us/windows/win32/menurc/about-resource-files
 
 # Licensing
 

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -25,6 +25,8 @@ set(PROJECT_SOURCES
     cppdocument.cpp
     cppdocument_p.h
     cppdocument_p.cpp
+    csharpdocument.h
+    csharpdocument.cpp
     functionsymbol.h
     functionsymbol.cpp
     dataexchange.h

--- a/src/core/codedocument.cpp
+++ b/src/core/codedocument.cpp
@@ -47,6 +47,8 @@ namespace Core {
  * functionality.
  *
  * This class provides the language-independent basis of integration with Tree-sitter and the LSP.
+ *
+ * Currently supported languages are: C/C++, Qml and C#
  */
 
 CodeDocument::~CodeDocument() = default;

--- a/src/core/core/settings.json
+++ b/src/core/core/settings.json
@@ -54,6 +54,7 @@
         "ico": "image_type",
         "slint": "slint_type",
         "qml": "qml_type",
+        "cs": "csharp_type",
         "ts": "qtts_type"
     },
     "text_editor": {

--- a/src/core/csharpdocument.cpp
+++ b/src/core/csharpdocument.cpp
@@ -1,0 +1,39 @@
+/*
+  This file is part of Knut.
+
+  SPDX-FileCopyrightText: 2025 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+
+  SPDX-License-Identifier: GPL-3.0-only
+
+  Contact KDAB at <info@kdab.com> for commercial licensing options.
+*/
+
+#include "csharpdocument.h"
+
+#include "codedocument_p.h"
+#include "symbol.h"
+
+namespace {
+
+QList<Core::Symbol *> queryAllSymbols(Core::CodeDocument *const document)
+{
+    Q_UNUSED(document);
+    // TODO
+    spdlog::warn("CSharpDocument::symbols: Symbols are not (yet) supported for C# code. "
+                 "Some functionality may not work as expected!");
+    return {};
+}
+
+} // anonymous namespace
+
+namespace Core {
+
+CSharpDocument::CSharpDocument(QObject *parent)
+    : CodeDocument(Type::CSharp, parent)
+{
+    helper()->querySymbols = queryAllSymbols;
+}
+
+CSharpDocument::~CSharpDocument() = default;
+
+} // namespace Core

--- a/src/core/csharpdocument.h
+++ b/src/core/csharpdocument.h
@@ -1,0 +1,26 @@
+/*
+  This file is part of Knut.
+
+  SPDX-FileCopyrightText: 2025 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+
+  SPDX-License-Identifier: GPL-3.0-only
+
+  Contact KDAB at <info@kdab.com> for commercial licensing options.
+*/
+
+#pragma once
+
+#include "codedocument.h"
+
+namespace Core {
+
+class CSharpDocument : public CodeDocument
+{
+    Q_OBJECT
+
+public:
+    explicit CSharpDocument(QObject *parent = nullptr);
+    ~CSharpDocument() override;
+};
+
+}

--- a/src/core/document.h
+++ b/src/core/document.h
@@ -36,6 +36,7 @@ public:
         Image,
         Slint,
         Qml,
+        CSharp,
         QtTs,
         Json,
     };
@@ -105,6 +106,7 @@ NLOHMANN_JSON_SERIALIZE_ENUM(Document::Type,
                               {Document::Type::Slint, "slint_type"},
                               {Document::Type::QtTs, "qtts_type"},
                               {Document::Type::Qml, "qml_type"},
+                              {Document::Type::CSharp, "csharp_type"},
                               {Document::Type::Json, "json_type"}})
 
 } // namespace Core

--- a/src/core/project.cpp
+++ b/src/core/project.cpp
@@ -10,6 +10,7 @@
 
 #include "project.h"
 #include "cppdocument.h"
+#include "csharpdocument.h"
 #include "imagedocument.h"
 #include "jsondocument.h"
 #include "logger.h"
@@ -221,6 +222,8 @@ static Document *createDocument(const QString &suffix)
         return new QtTsDocument();
     case Document::Type::Qml:
         return new QmlDocument();
+    case Document::Type::CSharp:
+        return new CSharpDocument();
     case Document::Type::Json:
         return new JsonDocument();
     default:

--- a/src/gui/apiexecutorwidget.cpp
+++ b/src/gui/apiexecutorwidget.cpp
@@ -10,6 +10,7 @@
 
 #include "apiexecutorwidget.h"
 #include "core/cppdocument.h"
+#include "core/csharpdocument.h"
 #include "core/imagedocument.h"
 #include "core/jsondocument.h"
 #include "core/logger.h"
@@ -76,6 +77,8 @@ static const QMetaObject *metaObjectFromType(Core::Document::Type type)
         return &Core::QtTsDocument::staticMetaObject;
     case Core::Document::Type::Json:
         return &Core::JsonDocument::staticMetaObject;
+    case Core::Document::Type::CSharp:
+        return &Core::CSharpDocument::staticMetaObject;
     }
     Q_UNREACHABLE();
 }

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -762,6 +762,7 @@ QWidget *MainWindow::widgetForDocument(Core::Document *document)
         tsView->setTsDocument(qobject_cast<Core::QtTsDocument *>(document));
         return tsView;
     }
+    case Core::Document::Type::CSharp:
     case Core::Document::Type::Cpp: {
         auto codeView = new CodeView();
         codeView->setDocument(qobject_cast<Core::CodeDocument *>(document));

--- a/src/treesitter/CMakeLists.txt
+++ b/src/treesitter/CMakeLists.txt
@@ -30,6 +30,7 @@ target_link_libraries(
   TreeSitter
   TreeSitterCpp
   TreeSitterQmlJs
+  TreeSitterCSharp
   kdalgorithms
   knut-utils
   Qt::Core)

--- a/src/treesitter/languages.h
+++ b/src/treesitter/languages.h
@@ -15,4 +15,5 @@ struct TSLanguage;
 extern "C" {
 TSLanguage *tree_sitter_cpp();
 TSLanguage *tree_sitter_qmljs();
+TSLanguage *tree_sitter_c_sharp();
 }

--- a/src/treesitter/parser.cpp
+++ b/src/treesitter/parser.cpp
@@ -75,6 +75,8 @@ TSLanguage *Parser::getLanguage(Core::Document::Type type)
         return tree_sitter_qmljs();
     case Core::Document::Type::Cpp:
         return tree_sitter_cpp();
+    case Core::Document::Type::CSharp:
+        return tree_sitter_c_sharp();
     default:
         Q_UNREACHABLE();
     }


### PR DESCRIPTION
Currently, this only includes basic support for the TreeSitter grammar,
without support for symbols or LSP.
