### PR TITLE
feat: Add basic support for Rust documents

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -35,3 +35,6 @@
 [submodule "3rdparty/tree-sitter-c-sharp"]
 	path = 3rdparty/tree-sitter-c-sharp
 	url = https://github.com/tree-sitter/tree-sitter-c-sharp.git
+[submodule "3rdparty/tree-sitter-rust"]
+	path = 3rdparty/tree-sitter-rust
+	url = https://github.com/tree-sitter/tree-sitter-rust.git

--- a/3rdparty/CMakeLists.txt
+++ b/3rdparty/CMakeLists.txt
@@ -111,3 +111,15 @@ target_link_libraries(${PROJECT_NAME} PRIVATE TreeSitter)
 # Always build tree-sitter with optimizations enabled. We shouldn't have to
 # debug it and it's performance critical.
 enable_optimizations(${PROJECT_NAME})
+
+# TreeSitterRust
+# ##############################################################################
+check_submodule(tree-sitter tree-sitter-rust)
+project(TreeSitterRust LANGUAGES C)
+
+add_library(${PROJECT_NAME} STATIC tree-sitter-rust/src/parser.c
+                                   tree-sitter-rust/src/scanner.c)
+target_link_libraries(${PROJECT_NAME} PRIVATE TreeSitter)
+# Always build tree-sitter with optimizations enabled. We shouldn't have to
+# debug it and it's performance critical.
+enable_optimizations(${PROJECT_NAME})

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Please refer to the subclasses of [Document](https://kdab.github.io/knut/API/knu
 |----------------------------|---------------|---------------|---------|---------------|
 | C/C++                      | ✅            | ✅            | ✅      |               |
 | C#                         | ✅            | ❌            | ❌      |               |
+| Rust                       | ✅            | ❌            | ❌      |               |
 | JSON                       | ❌            | ✔️             | ❌      |               |
 | [Qt Translate (.ts)][QtTs] | ❌            | ✔️             | ❌      |               |
 | [Qt Qml][Qml]              | ✅            | ✅            | ❌      | ✅             |

--- a/docs/API/knut/codedocument.md
+++ b/docs/API/knut/codedocument.md
@@ -39,6 +39,8 @@ functionality.
 
 This class provides the language-independent basis of integration with Tree-sitter and the LSP.
 
+Currently supported languages are: C/C++, Rust, Qml and C#
+
 ## Method Documentation
 
 #### <a name="findSymbol"></a>[Symbol](../knut/symbol.md) **findSymbol**(string name, int options = TextDocument.NoFindFlags)

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,6 +19,7 @@ Please refer to the subclasses of [Document](https://kdab.github.io/knut/API/knu
 |----------------------------|---------------|---------------|---------|---------------|
 | C/C++                      | ✅            | ✅            | ✅      |               |
 | C#                         | ✅            | ❌            | ❌      |               |
+| Rust                       | ✅            | ❌            | ❌      |               |
 | JSON                       | ❌            | ✔️             | ❌      |               |
 | [Qt Translate (.ts)][QtTs] | ❌            | ✔️             | ❌      |               |
 | [Qt Qml][Qml]              | ✅            | ✅            | ❌      | ✅             |

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -27,6 +27,8 @@ set(PROJECT_SOURCES
     cppdocument_p.cpp
     csharpdocument.h
     csharpdocument.cpp
+    rustdocument.h
+    rustdocument.cpp
     functionsymbol.h
     functionsymbol.cpp
     dataexchange.h

--- a/src/core/codedocument.cpp
+++ b/src/core/codedocument.cpp
@@ -47,7 +47,7 @@ namespace Core {
  *
  * This class provides the language-independent basis of integration with Tree-sitter and the LSP.
  *
- * Currently supported languages are: C/C++, Qml and C#
+ * Currently supported languages are: C/C++, Rust, Qml and C#
  */
 
 CodeDocument::~CodeDocument() = default;

--- a/src/core/core/settings.json
+++ b/src/core/core/settings.json
@@ -55,7 +55,8 @@
         "slint": "slint_type",
         "qml": "qml_type",
         "cs": "csharp_type",
-        "ts": "qtts_type"
+        "ts": "qtts_type",
+        "rs": "rust_type"
     },
     "text_editor": {
         "tab": {

--- a/src/core/document.h
+++ b/src/core/document.h
@@ -39,6 +39,7 @@ public:
         CSharp,
         QtTs,
         Json,
+        Rust,
     };
     Q_ENUM(Type)
 
@@ -107,7 +108,8 @@ NLOHMANN_JSON_SERIALIZE_ENUM(Document::Type,
                               {Document::Type::QtTs, "qtts_type"},
                               {Document::Type::Qml, "qml_type"},
                               {Document::Type::CSharp, "csharp_type"},
-                              {Document::Type::Json, "json_type"}})
+                              {Document::Type::Json, "json_type"},
+                              {Document::Type::Rust, "rust_type"}})
 
 } // namespace Core
 

--- a/src/core/project.cpp
+++ b/src/core/project.cpp
@@ -20,6 +20,7 @@
 #include "qttsdocument.h"
 #include "qtuidocument.h"
 #include "rcdocument.h"
+#include "rustdocument.h"
 #include "settings.h"
 #include "slintdocument.h"
 #include "textdocument.h"
@@ -226,6 +227,8 @@ static Document *createDocument(const QString &suffix)
         return new CSharpDocument();
     case Document::Type::Json:
         return new JsonDocument();
+    case Document::Type::Rust:
+        return new RustDocument();
     default:
         return new TextDocument();
     }

--- a/src/core/rustdocument.cpp
+++ b/src/core/rustdocument.cpp
@@ -1,0 +1,39 @@
+/*
+  This file is part of Knut.
+
+  SPDX-FileCopyrightText: 2025 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+
+  SPDX-License-Identifier: GPL-3.0-only
+
+  Contact KDAB at <info@kdab.com> for commercial licensing options.
+*/
+
+#include "rustdocument.h"
+
+#include "codedocument_p.h"
+#include "symbol.h"
+
+namespace {
+
+QList<Core::Symbol *> queryAllSymbols(Core::CodeDocument *const document)
+{
+    Q_UNUSED(document);
+    // TODO
+    spdlog::warn("RustDocument::symbols: Symbols are not (yet) supported for C# code. "
+                 "Some functionality may not work as expected!");
+    return {};
+}
+
+} // anonymous namespace
+
+namespace Core {
+
+RustDocument::RustDocument(QObject *parent)
+    : CodeDocument(Type::CSharp, parent)
+{
+    helper()->querySymbols = queryAllSymbols;
+}
+
+RustDocument::~RustDocument() = default;
+
+} // namespace Core

--- a/src/core/rustdocument.h
+++ b/src/core/rustdocument.h
@@ -1,0 +1,26 @@
+/*
+  This file is part of Knut.
+
+  SPDX-FileCopyrightText: 2025 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+
+  SPDX-License-Identifier: GPL-3.0-only
+
+  Contact KDAB at <info@kdab.com> for commercial licensing options.
+*/
+
+#pragma once
+
+#include "codedocument.h"
+
+namespace Core {
+
+class RustDocument : public CodeDocument
+{
+    Q_OBJECT
+
+public:
+    explicit RustDocument(QObject *parent = nullptr);
+    ~RustDocument() override;
+};
+
+}

--- a/src/gui/apiexecutorwidget.cpp
+++ b/src/gui/apiexecutorwidget.cpp
@@ -19,6 +19,7 @@
 #include "core/qttsdocument.h"
 #include "core/qtuidocument.h"
 #include "core/rcdocument.h"
+#include "core/rustdocument.h"
 #include "core/slintdocument.h"
 #include "guisettings.h"
 #include "ui_apiexecutorwidget.h"
@@ -79,6 +80,8 @@ static const QMetaObject *metaObjectFromType(Core::Document::Type type)
         return &Core::JsonDocument::staticMetaObject;
     case Core::Document::Type::CSharp:
         return &Core::CSharpDocument::staticMetaObject;
+    case Core::Document::Type::Rust:
+        return &Core::RustDocument::staticMetaObject;
     }
     Q_UNREACHABLE();
 }

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -763,6 +763,7 @@ QWidget *MainWindow::widgetForDocument(Core::Document *document)
         return tsView;
     }
     case Core::Document::Type::CSharp:
+    case Core::Document::Type::Rust:
     case Core::Document::Type::Cpp: {
         auto codeView = new CodeView(this);
         codeView->setDocument(qobject_cast<Core::CodeDocument *>(document));

--- a/src/treesitter/CMakeLists.txt
+++ b/src/treesitter/CMakeLists.txt
@@ -31,6 +31,7 @@ target_link_libraries(
   TreeSitterCpp
   TreeSitterQmlJs
   TreeSitterCSharp
+  TreeSitterRust
   kdalgorithms
   knut-utils
   Qt::Core)

--- a/src/treesitter/languages.h
+++ b/src/treesitter/languages.h
@@ -16,4 +16,5 @@ extern "C" {
 TSLanguage *tree_sitter_cpp();
 TSLanguage *tree_sitter_qmljs();
 TSLanguage *tree_sitter_c_sharp();
+TSLanguage *tree_sitter_rust();
 }

--- a/src/treesitter/parser.cpp
+++ b/src/treesitter/parser.cpp
@@ -77,6 +77,8 @@ TSLanguage *Parser::getLanguage(Core::Document::Type type)
         return tree_sitter_cpp();
     case Core::Document::Type::CSharp:
         return tree_sitter_c_sharp();
+    case Core::Document::Type::Rust:
+        return tree_sitter_rust();
     default:
         Q_UNREACHABLE();
     }


### PR DESCRIPTION
Currently, this only includes basic support for the TreeSitter grammar,
without support for symbols or LSP.
