### PR TITLE
Allow opening a different project

### DIFF
--- a/src/core/project.cpp
+++ b/src/core/project.cpp
@@ -96,12 +96,11 @@ bool Project::setRoot(const QString &newRoot)
     if (m_root == dir.absolutePath())
         return true;
 
-    if (m_root.isEmpty()) {
-        spdlog::info("{}: {}", FUNCTION_NAME, dir.absolutePath());
-    } else {
-        spdlog::error("{}: can't open a new project", FUNCTION_NAME);
-        return false;
-    }
+    if (!m_root.isEmpty())
+        for (auto client : m_lspClients | std::views::values)
+            client->closeProject(m_root);
+
+    spdlog::info("{}: {}", FUNCTION_NAME, dir.absolutePath());
 
     m_root = dir.absolutePath();
     Settings::instance()->loadProjectSettings(m_root);

--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -234,8 +234,13 @@ bool Settings::hasLsp() const
 void Settings::loadKnutSettings()
 {
     QFile file(":/core/settings.json");
-    if (file.open(QIODevice::ReadOnly))
+    if (file.open(QIODevice::ReadOnly)) {
         m_settings = nlohmann::json::parse(file.readAll().constData());
+        return;
+    }
+    spdlog::error("{}: {} - is missing from Qt Resources and thus settings cannot be initialized", FUNCTION_NAME,
+                  file.fileName());
+    Q_UNREACHABLE();
 }
 
 void Settings::saveSettings()

--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -49,9 +49,7 @@ Settings::Settings(Mode mode, QObject *parent)
     Q_ASSERT(m_instance == nullptr);
     m_instance = this;
 
-    loadKnutSettings();
-    if (!isTesting()) // Only load if not testing
-        loadUserSettings();
+    loadBaseSettings();
 
     m_saveTimer->callOnTimeout(this, &Settings::saveSettings);
     m_saveTimer->setSingleShot(true);
@@ -59,8 +57,15 @@ Settings::Settings(Mode mode, QObject *parent)
 
 Settings::~Settings()
 {
-    saveOnExit();
+    saveIfApplicable();
     m_instance = nullptr;
+}
+
+void Settings::loadBaseSettings()
+{
+    loadKnutSettings();
+    if (!isTesting()) // Only load if not testing
+        loadUserSettings();
 }
 
 Settings *Settings::instance()
@@ -85,6 +90,9 @@ void Settings::loadUserSettings()
 
 void Settings::loadProjectSettings(const QString &rootDir)
 {
+    saveIfApplicable();
+    loadBaseSettings();
+
     m_projectPath = rootDir;
 
     const QString fileName = projectFilePath();
@@ -246,7 +254,7 @@ void Settings::saveSettings()
     emit settingsSaved();
 }
 
-void Settings::saveOnExit()
+void Settings::saveIfApplicable()
 {
     if (m_saveTimer->isActive()) {
         saveSettings();

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -133,9 +133,10 @@ private:
 
     void loadKnutSettings();
     void loadUserSettings();
+    void loadBaseSettings();
     void updatePaths(const QString &path, const std::string &json_path, bool add);
     void saveSettings();
-    void saveOnExit();
+    void saveIfApplicable();
     bool isUser() const;
     void triggerLog(const Utils::LoadJsonStatus &loadJsonStatus, const QString &fileName, const QString &caller);
 

--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -59,7 +59,7 @@ private:
     void openProject();
     void saveDocument();
     void saveAllDocuments();
-    void closeDocument();
+    void closeDocument(int);
     void openOptions();
     void returnToEditor();
 


### PR DESCRIPTION
Opening a new project closes all files and replaces the current project.