### PR TITLE
fix: Prevent Knut from breaking file when writing plural translations

### DIFF
--- a/src/core/qttsdocument.cpp
+++ b/src/core/qttsdocument.cpp
@@ -387,7 +387,13 @@ void QtTsMessage::setTranslation(const QString &translation)
 {
     LOG(translation);
     m_message.child("translation").remove_attribute("type");
-    m_message.child("translation").text().set(translation.toUtf8().constData());
+    // Singular
+    if (!m_message.attribute("numerus").as_bool())
+        m_message.child("translation").text().set(translation.toUtf8().constData());
+    // Plural
+    else
+        qWarning() << "stub: Cannot set plural translation, not implemented.";
+    // Mark change
     qobject_cast<QtTsDocument *>(parent())->setHasChanged(true);
     Q_EMIT translationChanged();
 }


### PR DESCRIPTION
Writing a node_pcdata when a the numerusform node_element is already present results in a .ts file that can't be opened by QLinguist. This is a fix to prevent .ts files with plurals from getting broken by Knut. Proper support for plurals still needs to be added.