### PR TITLE
fix: cmake 4.0 support doesn't support cmake < 3.5 by default

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -2,9 +2,18 @@
     "version": 2,
     "configurePresets": [
         {
+            "name": "base",
+            "generator": "Ninja",
+            "binaryDir": "${sourceDir}/build-${presetName}",
+            "hidden": true,
+            "cacheVariables": {
+                "CMAKE_POLICY_VERSION_MINIMUM": "3.5"
+            }
+        },
+        {
             "name": "debug",
             "displayName": "Debug build",
-            "generator": "Ninja",
+            "inherits": "base",
             "binaryDir": "${sourceDir}/build-debug",
             "cacheVariables": {
                 "CMAKE_BUILD_TYPE": "Debug",
@@ -15,7 +24,6 @@
             "name": "debug-asan",
             "displayName": "Debug Asan build",
             "inherits": "debug",
-            "binaryDir": "${sourceDir}/build-debug-asan",
             "cacheVariables": {
                 "USE_ASAN": "ON"
             }
@@ -23,8 +31,7 @@
         {
             "name": "release",
             "displayName": "Release build",
-            "generator": "Ninja",
-            "binaryDir": "${sourceDir}/build-release",
+            "inherits": "base",
             "cacheVariables": {
                 "CMAKE_BUILD_TYPE": "Release"
             }
@@ -32,8 +39,7 @@
         {
             "name": "profile",
             "displayName": "Profile build",
-            "generator": "Ninja",
-            "binaryDir": "${sourceDir}/build-profile",
+            "inherits": "base",
             "cacheVariables": {
                 "CMAKE_BUILD_TYPE": "RelWithDebInfo"
             }


### PR DESCRIPTION
nlohmann-json still requires cmake 3.1
it's not supported by cmake 4.0

We need to use CMAKE_POLICY_VERSION_MINIMUM=3.5
