### PR TITLE
fix: file changed externally triggers the message all the time

### DIFF
--- a/src/core/document.cpp
+++ b/src/core/document.cpp
@@ -144,11 +144,16 @@ bool Document::hasChangedOnDisk() const
     return true;
 }
 
+void Document::clearChangedOnDisk()
+{
+    const QFileInfo fi(m_fileName);
+    m_lastModified = fi.lastModified();
+}
+
 void Document::reload()
 {
     doLoad(m_fileName);
-    const QFileInfo fi(m_fileName);
-    m_lastModified = fi.lastModified();
+    clearChangedOnDisk();
     emit fileUpdated();
 }
 

--- a/src/core/document.h
+++ b/src/core/document.h
@@ -61,6 +61,7 @@ public:
     bool hasChanged() const;
 
     bool hasChangedOnDisk() const;
+    void clearChangedOnDisk();
     void reload();
 
 public slots:

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -505,6 +505,9 @@ void MainWindow::reloadDocuments()
     if (result == QMessageBox::Yes) {
         for (auto *document : conflictDocs)
             document->reload();
+    } else {
+        for (auto *document : conflictDocs)
+            document->clearChangedOnDisk();
     }
 }
 


### PR DESCRIPTION
When a file is changed both internally and externally, a dialog shows
up on focus to ask to reload and lose the changes. If the answer was
no, the same dialog would have appeared again on the next focus.

It's now fixed, the dialog shows up only once.

Fix #252