### PR TITLE
Code optimization, especially toggling section

### DIFF
--- a/src/core/codedocument.cpp
+++ b/src/core/codedocument.cpp
@@ -134,7 +134,10 @@ void CodeDocument::deleteSymbol(const Symbol &symbol)
 Core::SymbolList CodeDocument::symbols() const
 {
     LOG();
-    return m_treeSitterHelper->symbols();
+    RangeMark::temporaryDocumentText = text();
+    const auto &symbols = m_treeSitterHelper->symbols();
+    RangeMark::temporaryDocumentText.clear();
+    return symbols;
 }
 
 struct RegexpTransform

--- a/src/core/logger.h
+++ b/src/core/logger.h
@@ -30,25 +30,31 @@
  * Log a method, with all its parameters.
  */
 #define LOG(...)                                                                                                       \
-    Core::LoggerObject __loggerObject(Core::formatToClassNameFunctionName(std::source_location::current()), false,     \
-                                      ##__VA_ARGS__)
+    Core::LoggerObject __loggerObject(                                                                                 \
+        Core::LoggerObject::canLog() ? Core::formatToClassNameFunctionName(std::source_location::current()) : "",      \
+        false, ##__VA_ARGS__)
 
 /**
  * Log a method, with all its parameters. If the previous log is also the same method, it will be merged into one
  * operation
  */
 #define LOG_AND_MERGE(...)                                                                                             \
-    Core::LoggerObject __loggerObject(Core::formatToClassNameFunctionName(std::source_location::current()), true,      \
-                                      ##__VA_ARGS__)
+    Core::LoggerObject __loggerObject(                                                                                 \
+        Core::LoggerObject::canLog() ? Core::formatToClassNameFunctionName(std::source_location::current()) : "",      \
+        true, ##__VA_ARGS__)
 
 /**
  * Macro to save the returned value in the historymodel
  */
 #define LOG_RETURN(name, value)                                                                                        \
     do {                                                                                                               \
-        const auto &__value = value;                                                                                   \
-        __loggerObject.setReturnValue(name, __value);                                                                  \
-        return __value;                                                                                                \
+        if (Core::LoggerObject::canLog()) {                                                                            \
+            const auto &__value = value;                                                                               \
+            __loggerObject.setReturnValue(name, __value);                                                              \
+            return __value;                                                                                            \
+        } else {                                                                                                       \
+            return value;                                                                                              \
+        }                                                                                                              \
     } while (false)
 
 namespace Core {
@@ -292,6 +298,8 @@ public:
         if (m_firstLogger && m_model)
             m_model->setReturnValue(std::move(name), value);
     }
+
+    static bool canLog() { return m_canLog; }
 
 private:
     friend HistoryModel;

--- a/src/core/rangemark.cpp
+++ b/src/core/rangemark.cpp
@@ -134,6 +134,9 @@ TextDocument *RangeMark::document() const
 
 QString RangeMark::text() const
 {
+    if (!isValid())
+        return {};
+
     auto text = temporaryDocumentText.isEmpty() ? document()->text() : temporaryDocumentText;
     // <= here instead of < because m_end is exclusive
     if (isValid() && end() <= text.size()) {

--- a/src/core/rangemark.cpp
+++ b/src/core/rangemark.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
   This file is part of Knut.
 
   SPDX-FileCopyrightText: 2024 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
@@ -134,9 +134,13 @@ TextDocument *RangeMark::document() const
 
 QString RangeMark::text() const
 {
+    auto text = temporaryDocumentText.isEmpty() ? document()->text() : temporaryDocumentText;
     // <= here instead of < because m_end is exclusive
-    if (isValid() && end() <= document()->text().size())
-        return document()->text().sliced(start(), end() - start());
+    if (isValid() && end() <= text.size()) {
+        text = text.sliced(start(), end() - start());
+        text.squeeze();
+        return text;
+    }
     return {};
 }
 

--- a/src/core/rangemark.h
+++ b/src/core/rangemark.h
@@ -1,4 +1,4 @@
-/*
+﻿/*
   This file is part of Knut.
 
   SPDX-FileCopyrightText: 2024 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
@@ -61,6 +61,11 @@ public:
     Q_INVOKABLE QString textExcept(const Core::RangeMark &other) const;
 
     bool operator==(const RangeMark &other) const;
+
+protected:
+    friend class CodeDocument;
+    // This is used to reduce memory allocations when extracting symbols
+    inline static QString temporaryDocumentText = {};
 
 private:
     std::shared_ptr<class RangeMarkPrivate> d = nullptr;

--- a/src/core/textdocument.cpp
+++ b/src/core/textdocument.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
   This file is part of Knut.
 
   SPDX-FileCopyrightText: 2024 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
@@ -428,7 +428,7 @@ int TextDocument::positionAt(int line, int column)
 QString TextDocument::text() const
 {
     LOG();
-    LOG_RETURN("text", m_document->toPlainText());
+    return m_document->toPlainText();
 }
 
 void TextDocument::setText(const QString &newText)

--- a/test_data/tst_cppdocument/toggleSection/section.cpp.expected
+++ b/test_data/tst_cppdocument/toggleSection/section.cpp.expected
@@ -64,3 +64,14 @@ Section *Section::create()
     return nullptr;
 #endif // KDAB_TEMPORARILY_REMOVED
 }
+
+Section &Section::reference()
+{
+#ifdef KDAB_TEMPORARILY_REMOVED
+    computeText();
+    return *m_pointer;
+#else // KDAB_TEMPORARILY_REMOVED
+    qDebug("Section::reference is commented out");
+    return {};
+#endif // KDAB_TEMPORARILY_REMOVED
+}

--- a/test_data/tst_cppdocument/toggleSection/section.cpp.original
+++ b/test_data/tst_cppdocument/toggleSection/section.cpp.original
@@ -44,3 +44,9 @@ Section *Section::create()
     computeText();
     return new Section;
 }
+
+Section &Section::reference()
+{
+    computeText();
+    return *m_pointer;
+}

--- a/test_data/tst_cppdocument/toggleSection/section.h
+++ b/test_data/tst_cppdocument/toggleSection/section.h
@@ -10,4 +10,7 @@ public:
     int bar();
 
     static Section *create();
+    Section &reference();
+private:
+    Section *m_pointer;
 };

--- a/tests/tst_cppdocument_clangd.cpp
+++ b/tests/tst_cppdocument_clangd.cpp
@@ -68,6 +68,8 @@ private slots:
             auto cppFile = qobject_cast<Core::CppDocument *>(Core::Project::instance()->get(file.fileName()));
 
             // Comment out full methods (start from the end)
+            cppFile->gotoLine(50);
+            cppFile->toggleSection();
             cppFile->gotoLine(42);
             cppFile->toggleSection();
             cppFile->gotoLine(35);


### PR DESCRIPTION
perf: Use a query for toggling section

    This is faster than getting all the symbols, as we don't need to do any
    kind of processing of the symbols.

perf: Optimize symbols creation

    No need to get the text from the document every time, this reduce the
    complexity a lot.
    Also squeeze the text from the range, to avoid using too much memory (as
    the string is the size of the file).

perf: Bypass logger if it's not needed

    We don't need to do anything if we can't log, so bypass the logger
    entirely.
    Also bypass a copy of the file during TextDocument::text(), as it's not